### PR TITLE
refactor(boostlist): Update logic to display boosted numbers

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -529,10 +529,10 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 		}
 	}
 
-	showBoostedNums := 2
-	windowSize := 10
+	showBoostedNums := 2 // Try to show at least 2 previously boosted
+	windowSize := 10     // Number lines to show a single booster
 	orderSubset := contract.Order
-	if contract.State != ContractStateSignup && len(contract.Order) > 16 {
+	if contract.State != ContractStateSignup && len(contract.Order) >= (windowSize+2) {
 		// extract 10 elements around the current booster
 		var start = contract.BoostPosition - showBoostedNums
 		var end = contract.BoostPosition + (windowSize - showBoostedNums)


### PR DESCRIPTION
Increase the window size to show a single booster to be 10 lines. 
Also, ensure that at least 2 previously boosted numbers are displayed. 
This change improves the visibility of boosted numbers in the boost list.