### PR TITLE
feat: Calculate token delta when token is sent

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -600,6 +600,7 @@ func ContractTokenSent(s *discordgo.Session, channelID string, userID string) {
 			v.TokenSentTime = append(v.TokenSentTime, now)
 			v.TokenSentValues = append(v.TokenSentValues, tokenValue)
 			v.TokenValueSent += tokenValue
+			v.TokenDelta = v.TokenValueSent - v.TokenValueReceived
 
 			str := getTokenTrackingString(v)
 			m := discordgo.NewMessageEdit(v.UserChannelID, v.TokenMessageID)


### PR DESCRIPTION
Calculate the token delta when a token is sent in order to keep track of the
difference between tokens sent and received more accurately.