### PR TITLE
feat: Save token data when token sent

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -601,7 +601,7 @@ func ContractTokenSent(s *discordgo.Session, channelID string, userID string) {
 			v.TokenSentValues = append(v.TokenSentValues, tokenValue)
 			v.TokenValueSent += tokenValue
 			v.TokenDelta = v.TokenValueSent - v.TokenValueReceived
-
+			saveData(Tokens)
 			str := getTokenTrackingString(v)
 			m := discordgo.NewMessageEdit(v.UserChannelID, v.TokenMessageID)
 			m.Components = getTokenValComponents(tokenTrackingEditing(userID, v.Name, false), v.Name)


### PR DESCRIPTION
Save the token data when a token is sent in order to keep track of token values
and calculate the token delta accurately.