### PR TITLE
fix: Modify contract token sent tracking to prevent nil pointer error

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1261,7 +1261,9 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 			if contract.BoostPosition < len(contract.Order) {
 				contract.Boosters[contract.Order[contract.BoostPosition]].TokensReceived++
 				emojiName = r.Emoji.Name + ":" + r.Emoji.ID
-				track.ContractTokenSent(s, r.ChannelID, r.UserID)
+				if r.UserID != contract.Order[contract.BoostPosition] {
+					track.ContractTokenSent(s, r.ChannelID, r.UserID)
+				}
 
 				var b = contract.Boosters[contract.Order[contract.BoostPosition]]
 				if b.TokensReceived >= b.TokensWanted && b.UserID == b.Name {

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -318,9 +318,8 @@ func ContractTokenSent(s *discordgo.Session, channelID string, userID string) {
 	if Tokens[userID] == nil {
 		return
 	}
-
 	for _, v := range Tokens[userID].Coop {
-		if v.ChannelID == channelID {
+		if v != nil && v.ChannelID == channelID {
 			now := time.Now()
 			offsetTime := now.Sub(v.StartTime).Seconds()
 			tokenValue := getTokenValue(offsetTime, v.DurationTime.Seconds())


### PR DESCRIPTION
Adjust the ContractTokenSent function in track.go to check if 'v' is not nil before comparing its ChannelID with the input parameter. This prevents a potential nil pointer error.