### PR TITLE
refactor: Fix variable name casing in component handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -1318,13 +1318,13 @@ func init() {
 		case discordgo.InteractionMessageComponent:
 
 			if h, ok := componentHandlers[i.MessageComponentData().CustomID]; ok {
-				userId := ""
+				userID := ""
 				if i.GuildID == "" {
-					userId = i.Member.User.ID
+					userID = i.Member.User.ID
 				} else {
-					userId = i.Member.User.ID
+					userID = i.Member.User.ID
 				}
-				fmt.Println("Component: ", i.MessageComponentData().CustomID, i.MessageComponentData().Values, userId)
+				fmt.Println("Component: ", i.MessageComponentData().CustomID, i.MessageComponentData().Values, userID)
 				h(s, i)
 			}
 		}


### PR DESCRIPTION
Fix the variable name casing from userId to userID for better consistency
and readability. Update related references accordingly.