### PR TITLE
feat: Add option to remove errant received tokens

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -203,6 +203,9 @@ func getTokenTrackingString(td *tokenValue, finalDisplay bool) string {
 					break
 				}
 			}
+			if td.LinkRecieved {
+				fmt.Fprintf(&builder, "React with 1️⃣..🔟 to remove errant received tokens at that index.\n", td.TokenDelta)
+			}
 		}
 		if !finalDisplay {
 			builder.WriteString("**Current")


### PR DESCRIPTION
When displaying token tracking information, now users have the option to
react with 1️⃣..🔟 to remove errant tokens that were received at a
specific index.