### PR TITLE
fix: Corrected typo in print function for tracking string

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -204,7 +204,7 @@ func getTokenTrackingString(td *tokenValue, finalDisplay bool) string {
 				}
 			}
 			if td.LinkRecieved {
-				fmt.Fprintf(&builder, "React with 1️⃣..🔟 to remove errant received tokens at that index.\n", td.TokenDelta)
+				fmt.Fprint(&builder, "React with 1️⃣..🔟 to remove errant received tokens at that index.\n", td.TokenDelta)
 			}
 		}
 		if !finalDisplay {


### PR DESCRIPTION
Updated the print function to correctly display instructions for removing
errant received tokens at a specific index in the tracking string.