### PR TITLE
fix: Remove unnecessary variable from getTokenTrackingString function

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -204,7 +204,7 @@ func getTokenTrackingString(td *tokenValue, finalDisplay bool) string {
 				}
 			}
 			if td.LinkRecieved {
-				fmt.Fprint(&builder, "React with 1️⃣..🔟 to remove errant received tokens at that index.\n", td.TokenDelta)
+				fmt.Fprint(&builder, "React with 1️⃣..🔟 to remove errant received tokens at that index.\n")
 			}
 		}
 		if !finalDisplay {


### PR DESCRIPTION
Removed the unused variable `td.TokenDelta` from the getTokenTrackingString
function in track/track.go to improve code clarity.