### PR TITLE
feat(track): Improve tracking of token sent and received

### DIFF
--- a/src/boost/boost_reactions.go
+++ b/src/boost/boost_reactions.go
@@ -158,10 +158,10 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 				if r.UserID != b.UserID {
 					// Record the Tokens as received
 					b.TokenReceivedTime = append(b.TokenReceivedTime, time.Now())
-					track.ContractTokenMessage(s, r.ChannelID, b.UserID, track.TokenReceived)
+					track.ContractTokenMessage(s, r.ChannelID, b.UserID, track.TokenReceived, r.UserID)
 
 					// Record who sent the token
-					track.ContractTokenMessage(s, r.ChannelID, r.UserID, track.TokenSent)
+					track.ContractTokenMessage(s, r.ChannelID, r.UserID, track.TokenSent, b.UserID)
 					contract.Boosters[r.UserID].TokenSentTime = append(contract.Boosters[r.UserID].TokenSentTime, time.Now())
 				} else {
 					track.FarmedToken(s, r.ChannelID, r.UserID)

--- a/src/track/track_handlers.go
+++ b/src/track/track_handlers.go
@@ -244,13 +244,18 @@ func HandleTokenCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	linkReceived := false
 	var duration time.Duration
 	if opt, ok := optionMap["duration"]; ok {
+		var err error
 		// Timespan of the contract duration
 		contractTimespan := strings.TrimSpace(opt.StringValue())
 		contractTimespan = strings.Replace(contractTimespan, "day", "d", -1)
 		contractTimespan = strings.Replace(contractTimespan, "hr", "h", -1)
 		contractTimespan = strings.Replace(contractTimespan, "min", "m", -1)
 		contractTimespan = strings.Replace(contractTimespan, "sec", "s", -1)
-		duration, _ = str2duration.ParseDuration(contractTimespan)
+		duration, err = str2duration.ParseDuration(contractTimespan)
+		if err != nil {
+			// Invalid duration, just assigning a 12h
+			duration = 12 * time.Hour
+		}
 	}
 	var trackingName = ""
 	if opt, ok := optionMap["name"]; ok {


### PR DESCRIPTION
- Assign a default duration of 12h if the duration string is invalid
- Add UserID tracking for sent and received tokens
- Include UserID in the display of sent and received tokens
- Enable removal of tokens using reactions for received tokens if not final display
- Track actorUserID in ContractTokenMessage for contract token actions.