### PR TITLE
refactor: Change message format when ping role is successfully changed

### DIFF
--- a/main.go
+++ b/main.go
@@ -1044,6 +1044,8 @@ var (
 				err := boost.ChangePingRole(s, i.GuildID, i.ChannelID, i.Member.User.ID, role.Mention())
 				if err != nil {
 					str += err.Error()
+				} else {
+					str = "Changed ping role to " + role.Mention() + "\n"
 				}
 			}
 			if opt, ok := optionMap["contract-id"]; ok {


### PR DESCRIPTION
Changed the format of the success message when ping role is updated to include
the mention of the new role.