### PR TITLE
feat: Ensure fair contract order in speedrun and fix token calculation

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1448,10 +1448,6 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 		} else {
 			RedrawBoostList(s, loc.GuildID, loc.ChannelID)
 		}
-		//if err == nil {
-		//SetListMessageID(contract, loc.ChannelID, msg.ID)
-		//}
-
 	}
 	if pingUsers {
 		notifyBellBoosters(s, contract)

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -96,6 +96,7 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, contractStarter 
 	contract.SRData.ChickenRuns = chickenRuns
 	contract.SRData.SpeedrunStyle = speedrunStyle
 	contract.SRData.SpeedrunState = SpeedrunStateSignup
+	contract.BoostOrder = ContractOrderFair
 
 	// Set up the details for the Chicken Run Tango
 	// first lap is CoopSize -1, every following lap is CoopSize -2
@@ -324,7 +325,11 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				//var sink *Booster
 				sink = contract.Boosters[contract.SRData.SinkUserID]
 
-				if r.UserID != b.UserID {
+				if r.UserID == b.UserID {
+					// Current booster subtract number of tokens wanted
+					sink.TokensReceived -= b.TokensWanted
+					sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens
+				} else {
 					// Current booster number of tokens wanted
 					b.TokensReceived += b.TokensWanted
 					sink.TokensReceived -= b.TokensWanted


### PR DESCRIPTION
Adjust how tokens are subtracted in speedrun reactions to avoid missing self-farmed
tokens. Set contract order as fair in speedrun options to ensure fairness in
contract order.