### PR TITLE
feat: Update linked and linkReceived variables if channelID is different

### DIFF
--- a/src/track/track_slashcmd.go
+++ b/src/track/track_slashcmd.go
@@ -88,8 +88,10 @@ func HandleTokenCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			// set channelID to last entry in the slice
 			channelID = s[len(s)-1]
 		}
-		linked = false
-		linkReceived = false
+		if channelID != i.ChannelID {
+			linked = false
+			linkReceived = false
+		}
 	}
 	// Call into boost module to do that calculations
 	var userID string


### PR DESCRIPTION
If the channelID is different from the interaction's ChannelID, set the linked
and linkReceived variables to false. This ensures proper functionality in the
boost module.