### PR TITLE
refactor: Update tango advancement message in boost_speedrun (#298)

### DIFF
--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -298,7 +298,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				keepReaction = true
 				// Indicate that the Sink is starting to kick users
 				str := "**Starting to kick users.** Swap shiny artifacts if you need to force a server sync.\n"
-				str += "Sink: React with 💃 after kicks to move to the next tango."
+				str += "Sink: React with 💃 after kicks to move to advance the tango."
 				msg, _ := s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 				s.MessageReactionAdd(contract.Location[0].ChannelID, msg.ID, "💃") // Tango Reaction
 				SetReactionID(contract, contract.Location[0].ChannelID, msg.ID)


### PR DESCRIPTION
Modified the message to better indicate that players should react with 💃
after kicks to advance the tango. This clarifies the instructions for
players participating in the boost speedrun.