### PR TITLE
refactor: Load contract data only if file exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -1273,8 +1273,9 @@ func downloadEggIncContracts() {
 func executeCronJob() {
 	if _, err := os.Stat(eggIncContractsFile); os.IsNotExist(err) {
 		downloadEggIncContracts()
+	} else {
+		boost.LoadContractData(eggIncContractsFile)
 	}
-	boost.LoadContractData(eggIncContractsFile)
 	gocron.Every(1).Day().At("16:00:15").Do(downloadEggIncContracts)
 	gocron.Every(1).Day().Do(boost.ArchiveContracts)
 


### PR DESCRIPTION
Only load contract data if the file exists to avoid unnecessary calls to
downloadEggIncContracts.