### PR TITLE
feat: Update contract state and boost position when booster leaves

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1080,7 +1080,9 @@ func removeContractBoosterByContract(s *discordgo.Session, contract *Contract, o
 	var currentBooster = ""
 
 	// Save current booster position
-	if contract.State != ContractStateWaiting {
+	if contract.State == ContractStateCompleted {
+		currentBooster = ""
+	} else if contract.State != ContractStateWaiting {
 		currentBooster = contract.Order[contract.BoostPosition]
 	}
 
@@ -1101,7 +1103,11 @@ func removeContractBoosterByContract(s *discordgo.Session, contract *Contract, o
 		}
 
 		// Active Booster is leaving contract.
-		if contract.State == ContractStateWaiting {
+		if contract.State == ContractStateCompleted {
+			contract.State = ContractStateWaiting
+			contract.BoostPosition--
+			sendNextNotification(s, contract, true)
+		} else if contract.State == ContractStateWaiting {
 			contract.BoostPosition = len(contract.Order)
 			sendNextNotification(s, contract, true)
 		} else if contract.State == ContractStateStarted && contract.BoostPosition == len(contract.Order) {


### PR DESCRIPTION
Adjust contract state and boost position when a booster leaves. If the contract
is completed, set the state to waiting and decrement the boost position. If the
contract is waiting, set the boost position to the length of the order.
Send the next notification accordingly.