### PR TITLE
refactor: Rename function HandleChangeCommand in boost_slashcmd.go

### DIFF
--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -384,7 +384,7 @@ func HandleBumpCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 }
 
-// HandlechangeCommand will handle the /change command
+// HandleChangeCommand will handle the /change command
 func HandleChangeCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	// Protection against DM use
 	if i.GuildID == "" {


### PR DESCRIPTION
Renamed the function HandlechangeCommand to HandleChangeCommand for
consistency and clarity when handling the /change command.