### PR TITLE
feat(boost): Add LegReactionMessageID to SpeedrunData

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -165,6 +165,7 @@ type SpeedrunData struct {
 	Legs                  int    // Number of legs for this Tango
 	Tango                 [3]int // The Tango itself (First, Middle, Last)
 	CurrentLeg            int    // Current Leg
+	LegReactionMessageID  string // Message ID for the Leg Reaction Message
 	StatusStr             string // Status string for the speedrun
 }
 

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -301,9 +301,10 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				msg, _ := s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 				s.MessageReactionAdd(contract.Location[0].ChannelID, msg.ID, "💃") // Tango Reaction
 				SetReactionID(contract, contract.Location[0].ChannelID, msg.ID)
+				contract.SRData.LegReactionMessageID = msg.ID
 			}
 
-			if r.Emoji.Name == "💃" {
+			if r.Emoji.Name == "💃" && r.MessageID == contract.SRData.LegReactionMessageID {
 				keepReaction = true
 
 				// Indicate that this Tango Leg is complete


### PR DESCRIPTION
Add LegReactionMessageID attribute to SpeedrunData structure to store the
Message ID for the Leg Reaction Message. Update the logic in speedrunReactions
function to set the LegReactionMessageID when the Tango reaction is added to a
message and validate the reaction based on the stored Message ID.