### PR TITLE
refactor: Modify token value field name in tracking embed

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -197,7 +197,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 		offsetTime := time.Since(td.StartTime).Seconds()
 
 		field = append(field, &discordgo.MessageEmbedField{
-			Name:   fmt.Sprintf("Token Value <t:%d:R>", time.Now().Unix()),
+			Name:   fmt.Sprintf("Value <t:%d:R>", time.Now().Unix()),
 			Value:  fmt.Sprintf("%1.3f\n", getTokenValue(offsetTime, td.DurationTime.Seconds())),
 			Inline: true,
 		})


### PR DESCRIPTION
Changed the field name in the tracking embed from "Token Value" to "Value" for
better clarity and consistency.