### PR TITLE
feat: Add /token-remove command and autocomplete

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ const slashSpeedrun string = "speedrun"
 const slashCoopETA string = "coopeta"
 const slashLaunchHelper string = "launch-helper"
 const slashToken string = "token"
+const slashTokenRemove string = "token-remove"
 const slashCalcContractTval string = "calc-contract-tval"
 const slashVolunteerSink string = "volunteer-sink"
 const slashFun string = "fun"
@@ -351,6 +352,7 @@ var (
 		boost.GetSlashCalcContractTval(slashCalcContractTval),
 		launch.SlashLaunchHelperCommand(slashLaunchHelper),
 		track.GetSlashTokenCommand(slashToken),
+		track.GetSlashTokenRemoveCommand(slashTokenRemove),
 		{
 			Name:        slashChange,
 			Description: "Change aspects of a running contract",
@@ -413,6 +415,20 @@ var (
 		slashChange: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleContractAutoComplete(s, i)
 		},
+		slashTokenRemove: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			sstr, cchoices := boost.HandleTokenRemoveAutoComplete(s, i)
+
+			str, choices := track.HandleTokenRemoveAutoComplete(s, i)
+			str = sstr + str
+			choices = append(choices, cchoices...)
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+				Data: &discordgo.InteractionResponseData{
+					Content: str,
+					Choices: choices,
+				}})
+
+		},
 	}
 
 	commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
@@ -435,6 +451,11 @@ var (
 		},
 		slashToken: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			track.HandleTokenCommand(s, i)
+		},
+		slashTokenRemove: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			if !boost.HandleTokenRemoveCommand(s, i) {
+				track.HandleTokenRemoveCommand(s, i)
+			}
 		},
 		slashCalcContractTval: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleContractCalcContractTvalCommand(s, i)

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -553,13 +553,33 @@ func removeReceivedToken(userID string, name string, index int) {
 		return
 	}
 
+	index--
 	for _, v := range Tokens[userID].Coop {
 		if v != nil && v.Name == name {
-			if index < len(v.TokenReceivedTime) {
+			if index <= len(v.TokenReceivedTime) {
 				v.SumValueReceived -= v.TokenReceivedValues[index]
 				v.TokenReceivedTime = append(v.TokenReceivedTime[:index], v.TokenReceivedTime[index+1:]...)
 				v.TokenReceivedValues = append(v.TokenReceivedValues[:index], v.TokenReceivedValues[index+1:]...)
 				v.TokenReceivedUserID = append(v.TokenReceivedUserID[:index], v.TokenReceivedUserID[index+1:]...)
+				v.TokenDelta = v.SumValueSent - v.SumValueReceived
+				saveData(Tokens)
+			}
+		}
+	}
+}
+
+func removeSentToken(userID string, name string, index int) {
+	if Tokens[userID] == nil {
+		return
+	}
+	index--
+	for _, v := range Tokens[userID].Coop {
+		if v != nil && v.Name == name {
+			if index < len(v.TokenSentTime) {
+				v.SumValueSent -= v.TokenSentValues[index]
+				v.TokenSentTime = append(v.TokenSentTime[:index], v.TokenSentTime[index+1:]...)
+				v.TokenSentValues = append(v.TokenSentValues[:index], v.TokenSentValues[index+1:]...)
+				v.TokenSentUserID = append(v.TokenSentUserID[:index], v.TokenSentUserID[index+1:]...)
 				v.TokenDelta = v.SumValueSent - v.SumValueReceived
 				saveData(Tokens)
 			}

--- a/src/track/track_slashcmd.go
+++ b/src/track/track_slashcmd.go
@@ -8,6 +8,8 @@ import (
 	"github.com/xhit/go-str2duration/v2"
 )
 
+var integerOneMinValue float64 = 1.0
+
 // GetSlashTokenCommand returns the slash command for token tracking
 func GetSlashTokenCommand(cmd string) *discordgo.ApplicationCommand {
 	return &discordgo.ApplicationCommand{
@@ -38,6 +40,47 @@ func GetSlashTokenCommand(cmd string) *discordgo.ApplicationCommand {
 				Name:        "contract-channel",
 				Description: "ChannelID or URL to Channel/Thread on Non-BootBot Server. Default is current channel.",
 				Required:    false,
+			},
+		},
+	}
+}
+
+// GetSlashTokenRemoveCommand returns the slash command for token tracking removal
+func GetSlashTokenRemoveCommand(cmd string) *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        cmd,
+		Description: "Remove a sent or received token from tracking",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+
+				Type:         discordgo.ApplicationCommandOptionString,
+				Name:         "token-list",
+				Description:  "The tracking list to remove the token from.",
+				Required:     true,
+				Autocomplete: true,
+			},
+			{
+				Name:        "token-type",
+				Description: "Select the type of token to remove from tracking.",
+				Required:    true,
+				Type:        discordgo.ApplicationCommandOptionInteger,
+				Choices: []*discordgo.ApplicationCommandOptionChoice{
+					{
+						Name:  "Sent Token",
+						Value: 0,
+					},
+					{
+						Name:  "Received Token",
+						Value: 1,
+					},
+				},
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionInteger,
+				Name:        "token-index",
+				Description: "Token index number to remove from tracking.",
+				MinValue:    &integerOneMinValue,
+				Required:    true,
 			},
 		},
 	}
@@ -122,4 +165,100 @@ func HandleTokenCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	},
 	)
 	saveData(Tokens)
+}
+
+// HandleTokenRemoveCommand will handle the /token-remove command
+func HandleTokenRemoveCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// User interacting with bot, is this first time ?
+	options := i.ApplicationCommandData().Options
+	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
+	for _, opt := range options {
+		optionMap[opt.Name] = opt
+	}
+	var userID string
+	if i.GuildID != "" {
+		userID = i.Member.User.ID
+	} else {
+		userID = i.User.ID
+	}
+
+	var tokenList string
+	var tokenType int
+	var tokenIndex int
+
+	if opt, ok := optionMap["token-list"]; ok {
+		tokenList = opt.StringValue()
+	}
+	if opt, ok := optionMap["token-type"]; ok {
+		tokenType = int(opt.IntValue())
+	}
+	if opt, ok := optionMap["token-index"]; ok {
+		tokenIndex = int(opt.IntValue())
+	}
+
+	// Need to figure out which list to remove from
+	if tokenType == 0 {
+		removeSentToken(userID, tokenList, tokenIndex)
+	} else {
+		removeReceivedToken(userID, tokenList, tokenIndex)
+	}
+	var str = "Token tracker not found in tracking list."
+	if Tokens[userID] != nil && Tokens[userID].Coop[tokenList] != nil {
+		str = "Token removed from tracking on <#" + Tokens[userID].Coop[tokenList].UserChannelID + ">."
+
+		defer saveData(Tokens)
+		embed := tokenTrackingTrack(userID, tokenList, 0, 0) // No sent or received
+		comp := getTokenValComponents(tokenTrackingEditing(userID, tokenList, false), tokenList)
+		m := discordgo.NewMessageEdit(Tokens[userID].Coop[tokenList].UserChannelID, Tokens[userID].Coop[tokenList].TokenMessageID)
+		m.Components = &comp
+		m.SetEmbeds(embed.Embeds)
+		m.SetContent("")
+		_, err := s.ChannelMessageEditComplex(m)
+		if err != nil {
+			str = "Error updating the token message. " + err.Error()
+		}
+	}
+
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: str,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	},
+	)
+	saveData(Tokens)
+}
+
+// HandleTokenRemoveAutoComplete will handle the /token-remove autocomplete
+func HandleTokenRemoveAutoComplete(s *discordgo.Session, i *discordgo.InteractionCreate) (string, []*discordgo.ApplicationCommandOptionChoice) {
+	// User interacting with bot, is this first time ?
+	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
+
+	var userID string
+	if i.GuildID != "" {
+		userID = i.Member.User.ID
+	} else {
+		userID = i.User.ID
+	}
+
+	if _, ok := Tokens[userID]; !ok {
+		return "", nil
+	}
+	for _, c := range Tokens[userID].Coop {
+		choice := discordgo.ApplicationCommandOptionChoice{
+			Name:  c.Name,
+			Value: c.Name,
+		}
+		choices = append(choices, &choice)
+	}
+	/*
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+			Data: &discordgo.InteractionResponseData{
+				Content: "Select tracker to adjust the token.",
+				Choices: choices,
+			}})*/
+	return "Select tracker to adjust the token.", choices
+
 }


### PR DESCRIPTION
Added a new command /token-remove to remove sent or received tokens from
tracking lists. Also added autocomplete functionality for the command.
Adjusted the token tracking structure accordingly.