### PR TITLE
fix: Adjust tokensToSend logic in speedrunReactions

### DIFF
--- a/main.go
+++ b/main.go
@@ -876,13 +876,13 @@ func downloadEggIncContracts() bool {
 		log.Print(err)
 		return false
 	}
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Print(err)
 		return false
 	}
+	defer resp.Body.Close()
 
 	// Check if the file already exists
 	_, err = os.Stat(eggIncContractsFile)
@@ -915,7 +915,6 @@ func executeCronJob() {
 	   at utc 16, 17, and 18 it checks on the hour and every minute for the first 9 minutes after and then every 5 minutes the rest of the hour. The rest of the time it checks every 30 minutes. It happens rarely but sometimes contracts get released late.
 
 	   TLDR yes it checks right at contract release time and also fairly frequently for the next hour or two after contract release time and then every 30 minutes
-
 	*/
 	gocron.Every(1).Day().At("16:00:05").Do(downloadEggIncContracts)
 	gocron.Every(1).Day().At("16:00:15").Do(downloadEggIncContracts)
@@ -926,6 +925,7 @@ func executeCronJob() {
 	gocron.Every(1).Day().Do(boost.ArchiveContracts)
 
 	<-gocron.Start()
+	log.Print("Exiting cron job")
 }
 
 func main() {
@@ -939,7 +939,8 @@ func main() {
 	go executeCronJob()
 
 	s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
-		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)
+		log.Printf("Ready message for: %v#%v", s.State.User.Username, s.State.User.Discriminator)
+		log.Printf("Ready Vers:%v  SessId:%v", r.Version, r.SessionID)
 	})
 	err := s.Open()
 	if err != nil {

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -326,6 +326,10 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 		if slices.Index(contract.CreatorID, "430186990260977665") == -1 {
 			contract.CreatorID = append(contract.CreatorID, "430186990260977665") // Aggie user id
 		}
+		if slices.Index(contract.CreatorID, "184063956539670528") == -1 {
+			contract.CreatorID = append(contract.CreatorID, "184063956539670528") // Halcyon user id
+		}
+
 		contract.RegisteredNum = 0
 		contract.CoopSize = coopSize
 		Contracts[ContractHash] = contract

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -324,7 +324,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 			s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 		}
 
-		if r.UserID == contract.SRData.SpeedrunStarterUserID {
+		if r.UserID == contract.SRData.SpeedrunStarterUserID || creatorOfContract(contract, r.UserID) {
 			if r.Emoji.Name == "🦵" {
 				keepReaction = true
 				// Indicate that the Sink is starting to kick users
@@ -340,7 +340,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				}
 			}
 
-			if r.Emoji.Name == "💃" && r.MessageID == contract.SRData.LegReactionMessageID {
+			if r.Emoji.Name == "💃" {
 				keepReaction = true
 
 				// Indicate that this Tango Leg is complete
@@ -377,7 +377,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 					log.Printf("Sink sent %d tokens to booster\n", b.TokensWanted)
 					// Current booster number of tokens wanted
 					// How many tokens does booster want?  Check to see if sink has that many
-					tokensToSend := min(b.TokensWanted, sink.TokensReceived)
+					tokensToSend := b.TokensWanted // If Sink is pressing 💰 they are assumed to be sending that many
 					b.TokensReceived += tokensToSend
 					sink.TokensReceived -= tokensToSend
 					sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens


### PR DESCRIPTION
Assume Sink sends same number when pressing money emoji. Fix contract
creator identification logic. Update conditions for reaction handling.