### PR TITLE
feat: Update signup count display in BoostList

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -168,6 +168,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 				sinkIcon := ""
 				if contract.SRData.SinkUserID == b.UserID {
 					sinkIcon = fmt.Sprintf("%s[%d] %s", tokenStr, b.TokensReceived, "🫂")
+					signupCountStr = fmt.Sprint(b.TokensWanted)
 				}
 				switch b.BoostState {
 				case BoostStateUnboosted:


### PR DESCRIPTION
Sink booster will always so total number of tokens wanted, just like all other farmers.