### PR TITLE
feat: Add functionality to save all data

### DIFF
--- a/main.go
+++ b/main.go
@@ -1006,6 +1006,9 @@ func main() {
 	log.Println("Press Ctrl+C to exit")
 	<-stop
 
+	boost.SaveAllData()
+	track.SaveAllData()
+
 	if *RemoveCommands {
 		log.Println("Removing commands...")
 

--- a/src/boost/boost_datastore.go
+++ b/src/boost/boost_datastore.go
@@ -3,12 +3,19 @@ package boost
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/peterbourgon/diskv/v3"
 )
 
 var dataStore *diskv.Diskv
+
+// SaveAllData will remove a token from the Contracts
+func SaveAllData() {
+	log.Print("Saving contact data")
+	saveData(Contracts)
+}
 
 func initDataStore() {
 


### PR DESCRIPTION
Add SaveAllData function in boost_datastore.go file to remove a token from the Contracts and save the contact data. Update the main.go file to call SaveAllData function for both boost and track packages.