### PR TITLE
feat: Add manual check for new Egg Inc contract data

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ const boostBotHomeGuild string = "766330702689992720"
 const slashAdminContractsList string = "contract-list"
 const slashAdminContractFinish string = "contract-finish"
 const slashAdminBotSettings string = "bot-settings"
+const slashReloadContracts string = "reload-contracts"
 
 // Slash Command Constants
 const slashContract string = "contract"
@@ -130,6 +131,10 @@ var (
 					Required:    true,
 				},
 			},
+		},
+		{
+			Name:        slashReloadContracts,
+			Description: "Manual check for new Egg Inc contract data.",
 		},
 	}
 
@@ -439,6 +444,9 @@ var (
 		},
 		slashAdminContractFinish: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleAdminContractFinish(s, i)
+		},
+		slashReloadContracts: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			tasks.HandleReloadContractsCommand(s, i)
 		},
 		// Normal Commands
 		slashJoin: func(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/bwmarrin/discordgo"
 	"github.com/jasonlvhit/gocron"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/boost"
 )
@@ -17,6 +18,24 @@ const eggIncContractsURL string = "https://raw.githubusercontent.com/carpetsage/
 const eggIncContractsFile string = "ttbb-data/ei-contracts.json"
 
 var lastContractUpdate time.Time
+
+// HandleReloadContractsCommand will handle the /reload command
+func HandleReloadContractsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	str := "No updated Egg Inc contract data available"
+
+	result := downloadEggIncContracts()
+	if result {
+		str += "New contract data loaded"
+	}
+
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content:    str,
+			Flags:      discordgo.MessageFlagsEphemeral,
+			Components: []discordgo.MessageComponent{}},
+	})
+}
 
 func isNewEggIncContractDataAvailable() bool {
 	req, err := http.NewRequest("GET", eggIncContractsURL, nil)


### PR DESCRIPTION
Add a new command to manually check for updated Egg Inc contract data in
Discord. When the command is called, the bot will attempt to download the
latest contracts and notify the user if new data has been loaded or not.