### PR TITLE
feat: Add new commands for volunteering as token sink

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/boost"
@@ -48,6 +49,7 @@ const slashToken string = "token"
 const slashTokenRemove string = "token-remove"
 const slashCalcContractTval string = "calc-contract-tval"
 const slashVolunteerSink string = "volunteer-sink"
+const slashVoluntellSink string = "voluntell-sink"
 const slashFun string = "fun"
 
 var integerZeroMinValue float64 = 0.0
@@ -352,6 +354,7 @@ var (
 			},
 		},
 		boost.GetSlashVolunteerSink(slashVolunteerSink),
+		boost.GetSlashVoluntellSink(slashVoluntellSink),
 		boost.GetSlashCalcContractTval(slashCalcContractTval),
 		{
 			Name:        slashChange,
@@ -483,6 +486,9 @@ var (
 		},
 		slashVolunteerSink: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleSlashVolunteerSinkCommand(s, i)
+		},
+		slashVoluntellSink: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleSlashVoluntellSinkCommand(s, i)
 		},
 		slashContract: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleContractCommand(s, i)

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -97,10 +97,10 @@ const (
 
 // TokenUnit holds the data for each token
 type TokenUnit struct {
-	Time   time.Time
-	Value  float64
-	UserID string // Who sent or received the token
-	Serial string // Serial number of the token
+	Time   time.Time // Time token was received
+	Value  float64   // Last calculated value of the token
+	UserID string    // Who sent or received the token
+	Serial string    // Serial number of the token
 }
 
 // Booster holds the data for each booster within a Contract

--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 )
 
-var adminUsers = []string{config.AdminUserID, "238786501700222986", "393477262412087319", "430186990260977665", "184063956539670528"}
+var adminUsers = []string{"238786501700222986", "393477262412087319", "430186990260977665", "184063956539670528"}
 
 // HandleAdminContractFinish is called when the contract is complete
 func HandleAdminContractFinish(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -17,7 +17,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 	outputStr = fmt.Sprintf("## %s/%s - 📋%s - %d/%d\n", contract.ContractID, contract.CoopID, getBoostOrderString(contract), len(contract.Boosters), contract.CoopSize)
 	outputStr += fmt.Sprintf("> Coordinator: <@%s>  <%s/%s/%s>\n", contract.CreatorID[0], "https://eicoop-carpet.netlify.app", contract.ContractID, contract.CoopID)
 	if !contract.Speedrun && contract.VolunteerSink != "" {
-		outputStr += fmt.Sprintf("> Post Contract Sink: %s\n", contract.Boosters[contract.VolunteerSink].Mention)
+		outputStr += fmt.Sprintf("> Post Contract Sink: %s\n", contract.VolunteerSink)
 	}
 	if contract.Speedrun {
 		switch contract.SRData.SpeedrunState {

--- a/src/boost/boost_sink.go
+++ b/src/boost/boost_sink.go
@@ -1,41 +1,140 @@
 package boost
 
-import "github.com/bwmarrin/discordgo"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
 
 // GetSlashVolunteerSink is used to volunteer as token sink for a contract
 func GetSlashVolunteerSink(cmd string) *discordgo.ApplicationCommand {
 	return &discordgo.ApplicationCommand{
 		Name:        cmd,
 		Description: "Volunteer as token sink for this contract",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "confirm",
+				Description: "Confirm you want to be the token sink. Default is false.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+// GetSlashVoluntellSink is used to volunteer as token sink for a contract
+func GetSlashVoluntellSink(cmd string) *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        cmd,
+		Description: "Voluntell guest farmer to assign as token sink for this contract",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "farmer",
+				Description: "Guest farmer to use as the token sink for this contract.",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "confirm",
+				Description: "Confirm you want to be the token sink.  Default is false.",
+				Required:    true,
+			},
+		},
 	}
 }
 
 // HandleSlashVolunteerSinkCommand is used to volunteer as token sink for a contract
 func HandleSlashVolunteerSinkCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	// User interacting with bot, is this first time ?
-	str := "Volunteering as token sink for this contract"
+	str := "Volunteering as token sink for this contract. It will show up on the next boost list refresh."
+	confirm := false
+
+	options := i.ApplicationCommandData().Options
+	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
+	for _, opt := range options {
+		optionMap[opt.Name] = opt
+	}
+	if opt, ok := optionMap["confirm"]; ok {
+		confirm = opt.BoolValue()
+	}
 
 	// Find the contract
 	var contract = FindContract(i.Interaction.ChannelID)
 	if contract == nil {
 		str = "No contract found in this channel"
 	} else {
-		if contract.Speedrun {
+		if !confirm {
+			str = "You must confirm you want to be the token sink"
+		} else if contract.Speedrun {
+			str = "You cannot use this command on a speedrun contract"
+		} else {
+			// Check if user is already in contract
+			if userInContract(contract, i.Interaction.Member.User.ID) {
+				contract.VolunteerSink = i.Interaction.Member.User.Mention()
+				if contract.State == ContractStateCompleted || contract.State == ContractStateWaiting {
+					RedrawBoostList(s, i.GuildID, i.ChannelID)
+				}
+			} else {
+				str = "You are not in this contract"
+			}
+		}
+	}
+
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: str,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	},
+	)
+}
+
+// HandleSlashVoluntellSinkCommand is used to volunteer as token sink for a contract
+func HandleSlashVoluntellSinkCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// User interacting with bot, is this first time ?
+	str := "Voluntell as token sink for this contract. It will show up on the next boost list refresh."
+
+	options := i.ApplicationCommandData().Options
+	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
+	for _, opt := range options {
+		optionMap[opt.Name] = opt
+	}
+
+	var VoluntellName string
+	confirm := false
+
+	if opt, ok := optionMap["farmer"]; ok {
+		VoluntellName = opt.StringValue()
+	}
+
+	if opt, ok := optionMap["confirm"]; ok {
+		confirm = opt.BoolValue()
+	}
+
+	// Find the contract
+	var contract = FindContract(i.Interaction.ChannelID)
+	if contract == nil {
+		str = "No contract found in this channel"
+	} else {
+		if !confirm {
+			str = "You must confirm you want to be the token sink"
+		} else if strings.HasPrefix(VoluntellName, "<@") {
+			str = "This should be a guest farmer within this contract and not a user mention."
+		} else if contract.Speedrun {
 			str = "You cannot use this command on a speedrun contract"
 		} else {
 			// if VolunteerSink is already set, reply with error
-			if contract.VolunteerSink != "" {
-				str = "Post contract sink already claimed by <@" + contract.VolunteerSink + ">"
-			} else {
-				// Check if user is already in contract
-				if userInContract(contract, i.Interaction.Member.User.ID) {
-					contract.VolunteerSink = i.Interaction.Member.User.ID
-					if contract.State == ContractStateCompleted {
-						RedrawBoostList(s, i.GuildID, i.ChannelID)
-					}
-				} else {
-					str = "You are not in this contract"
+			// Check if user is already in contract
+			if userInContract(contract, VoluntellName) {
+				contract.VolunteerSink = fmt.Sprintf("**%s**", VoluntellName)
+				if contract.State == ContractStateCompleted || contract.State == ContractStateWaiting {
+					RedrawBoostList(s, i.GuildID, i.ChannelID)
 				}
+			} else {
+				str = "They are not in this contract"
 			}
 		}
 	}


### PR DESCRIPTION
Added two new commands to allow users to volunteer as a token sink for a contract:
- GetSlashVolunteerSink: Volunteer as token sink, with confirmation option
- GetSlashVoluntellSink: Voluntell guest farmer as token sink, with farmer and confirmation options.