### PR TITLE
feat(boost): Update sendNextNotification to use UserID instead of Mention

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1434,7 +1434,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 							if einame != "" {
 								einame += " " // Add a space to this
 							}
-							name := einame + contract.Boosters[contract.VolunteerSink].Mention
+							name := einame + contract.Boosters[contract.VolunteerSink].UserID
 							str = fmt.Sprintf(loc.ChannelPing+" send tokens to our volunteer sink %s", name)
 						}
 					}


### PR DESCRIPTION
Replace Mention with UserID in the name variable for sending tokens to the volunteer sink.