### PR TITLE
feat: Add protobuf fields to EggIncContract

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/dannav/hhmmss v1.0.0
 	github.com/divan/num2words v0.0.0-20170904212200-57dba452f942
 	github.com/ewohltman/discordgo-mock v0.0.11
-	github.com/golang/protobuf v1.5.4
 	github.com/google/generative-ai-go v0.11.0
 	github.com/jasonlvhit/gocron v0.0.1
 	github.com/peterbourgon/diskv/v3 v3.0.1
@@ -33,6 +32,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -57,4 +57,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240415180920-8c6c420018be // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
 	google.golang.org/grpc v1.63.2 // indirect
+
 )

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/jasonlvhit/gocron v0.0.1 h1:qTt5qF3b3srDjeOIR4Le1LfeyvoYzJlYpqvG7tJX5
 github.com/jasonlvhit/gocron v0.0.1/go.mod h1:k9a3TV8VcU73XZxfVHCHWMWF9SOqgoku0/QlY2yvlA4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/levenlabs/golib v0.0.0-20180911183212-0f8974794783 h1:ErBsqZpyadTBr2zGsgMau0JdyghyLdwRRHAKJukexrQ=
-github.com/levenlabs/golib v0.0.0-20180911183212-0f8974794783/go.mod h1:zw8z7nRRkGDZHexz1aMbZGtwxli5so0CBVZeIa3G+RE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1738,8 +1738,11 @@ func ArchiveContracts() {
 
 // EggIncContract is a raw contract data for Egg Inc
 type EggIncContract struct {
-	ID    string `json:"id"`
-	Proto string `json:"proto"`
+	ID                        string `json:"id"`
+	Proto                     string `json:"proto"`
+	MaxCoopSize               int
+	LengthInSeconds           int
+	ChickenRunCooldownMinutes int
 }
 
 // EggIncContracts holds a list of all contracts, newest is last
@@ -1773,6 +1776,9 @@ func LoadContractData(filename string) {
 		contractTime := time.Unix(expirationTime, 0)
 
 		if contractTime.After(time.Now().UTC()) {
+			c.MaxCoopSize = int((*(*decodedBuf).MaxCoopSize))
+			c.LengthInSeconds = int((*(*decodedBuf).LengthSeconds))
+			c.ChickenRunCooldownMinutes = int((*(*decodedBuf).ChickenRunCooldownMinutes))
 			EggIncContracts = append(EggIncContracts, c)
 		}
 	}


### PR DESCRIPTION
Add new protobuf fields (MaxCoopSize, LengthInSeconds,
ChickenRunCooldownMinutes) to EggIncContract in boost.go.