### PR TITLE
feat: Update Co-op Size logic and description

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,8 +166,8 @@ var (
 				{
 					Type:        discordgo.ApplicationCommandOptionInteger,
 					Name:        "coop-size",
-					Description: "Co-op Size",
-					Required:    true,
+					Description: "Co-op Size. This will be pulled from EI Contract data if unset.",
+					Required:    false,
 				},
 				{
 					Name:        "boost-order",

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -154,15 +154,16 @@ type Contract struct {
 	Location     []*LocationData
 	CreatorID    []string // Slice of creators
 	//SignupMsgID    map[string]string // Message ID for the Signup Message
-	ContractID    string // Contract ID
-	CoopID        string // CoopID
-	CoopSize      int
-	BoostOrder    int // How the contract is sorted
-	BoostVoting   int
-	BoostPosition int       // Starting Slot
-	State         int       // Boost Completed
-	StartTime     time.Time // When Contract is started
-	EndTime       time.Time // When final booster ends
+	ContractID      string // Contract ID
+	CoopID          string // CoopID
+	CoopSize        int
+	LengthInSeconds int
+	BoostOrder      int // How the contract is sorted
+	BoostVoting     int
+	BoostPosition   int       // Starting Slot
+	State           int       // Boost Completed
+	StartTime       time.Time // When Contract is started
+	EndTime         time.Time // When final booster ends
 	//EggFarmers     map[string]*EggFarmer
 	RegisteredNum  int
 	Boosters       map[string]*Booster // Boosters Registered
@@ -347,6 +348,15 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 
 		contract.RegisteredNum = 0
 		contract.CoopSize = coopSize
+		if coopSize == 0 {
+			// Pull size from Contract
+			for _, cc := range EggIncContracts {
+				if cc.ID == contractID {
+					contract.CoopSize = cc.MaxCoopSize
+					contract.LengthInSeconds = cc.LengthInSeconds
+				}
+			}
+		}
 		Contracts[ContractHash] = contract
 	} else { //if !creatorOfContract(contract, userID) {
 		//contract.mutex.Lock()

--- a/src/boost/boost_help.go
+++ b/src/boost/boost_help.go
@@ -29,7 +29,7 @@ func GetHelp(s *discordgo.Session, guildID string, channelID string, userID stri
 		> **/contract**
 		> * *contract-id* : Contract name
 		> * *coop-id* : Coop name
-		> * *coop-size* : Number of farmers for the coop.
+		> * *coop-size* : Number of farmers for the coop. (optional)
 		> * *boost-order* : (opt)
 		>  * *Sign-up Order* : Default. Boosters are ordered in the order they join.
 		>  * *Random Order* : Randomized when the contract starts. After 20 minutes the order changes to Sign-up.

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -29,7 +29,7 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	var contractID = i.GuildID
 	var coopID = i.GuildID // Default to the Guild ID
 	var boostOrder = ContractOrderSignup
-	var coopSize = 2
+	var coopSize = 0
 	var ChannelID = i.ChannelID
 	var pingRole = "@here"
 


### PR DESCRIPTION
- Co-op Size is now optional in boost_help.go and boost_slashcmd.go.
- Co-op Size will be pulled from the Contract data if unset in main.go.
- Added CoopSize, LengthInSeconds fields to Contract struct in boost.go.
- Updated CreateContract to set Co-op Size from Contract data if unset.