### PR TITLE
feat: Set ChickenRuns on contract creation based on contract length

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -354,6 +354,7 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 				if cc.ID == contractID {
 					contract.CoopSize = cc.MaxCoopSize
 					contract.LengthInSeconds = cc.LengthInSeconds
+					contract.SRData.ChickenRuns = cc.ChickenRuns
 				}
 			}
 		}
@@ -1751,6 +1752,7 @@ type EggIncContract struct {
 	ID                        string `json:"id"`
 	Proto                     string `json:"proto"`
 	MaxCoopSize               int
+	ChickenRuns               int
 	LengthInSeconds           int
 	ChickenRunCooldownMinutes int
 }
@@ -1789,6 +1791,14 @@ func LoadContractData(filename string) {
 			c.MaxCoopSize = int((*(*decodedBuf).MaxCoopSize))
 			c.LengthInSeconds = int((*(*decodedBuf).LengthSeconds))
 			c.ChickenRunCooldownMinutes = int((*(*decodedBuf).ChickenRunCooldownMinutes))
+			if c.LengthInSeconds > 0 {
+				var d time.Duration
+				d = time.Duration(c.LengthInSeconds) * time.Second
+				days := int(d.Hours() / 24) // 2 days
+
+				c.ChickenRuns = min(20, (days*c.MaxCoopSize)/2)
+			}
+
 			EggIncContracts = append(EggIncContracts, c)
 		}
 	}

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -99,7 +99,6 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, contractStarter 
 	contract.SRData.SpeedrunStarterUserID = contractStarter
 	contract.SRData.SinkUserID = sink
 	contract.SRData.SinkBoostPosition = sinkPosition
-	contract.SRData.ChickenRuns = chickenRuns
 	contract.SRData.SelfRuns = selfRuns
 	contract.SRData.SpeedrunStyle = speedrunStyle
 	contract.SRData.SpeedrunState = SpeedrunStateSignup
@@ -107,12 +106,8 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, contractStarter 
 
 	// Chicken Runs Calc
 	// Info from https://egg-inc.fandom.com/wiki/Contracts
-	if contract.LengthInSeconds > 0 && chickenRuns == 0 {
-		var d time.Duration
-		d = time.Duration(contract.LengthInSeconds) * time.Second
-		days := int(d.Hours() / 24) // 2 days
-
-		contract.SRData.ChickenRuns = min(20, (days*contract.CoopSize)/2)
+	if chickenRuns != 0 {
+		contract.SRData.ChickenRuns = chickenRuns
 	}
 
 	// Set up the details for the Chicken Run Tango


### PR DESCRIPTION
When creating a contract, calculate and set the ChickenRuns based on the
contract length, coop size, and cooldown. Updated handling of ChickenRuns
assignment in contract creation and initialization.