### PR TITLE
feat: Add functionality to handle contract deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -587,21 +587,7 @@ var (
 
 	componentHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"fd_delete": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			// Delete coop
-			var str = "Contract not found."
-			coopName, err := boost.DeleteContract(s, i.GuildID, i.ChannelID)
-			if err == nil {
-				str = fmt.Sprintf("Contract %s deleted.", coopName)
-			}
-
-			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-				Type: discordgo.InteractionResponseUpdateMessage,
-				Data: &discordgo.InteractionResponseData{
-					Content:    str,
-					Flags:      discordgo.MessageFlagsEphemeral,
-					Components: []discordgo.MessageComponent{}},
-			})
-			s.ChannelMessageDelete(i.ChannelID, i.Message.ID)
+			boost.HandleContractDelete(s, i)
 		},
 		"fd_tokens5": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.AddBoostTokens(s, i, 5, 0)

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -50,6 +50,15 @@ func GetSignupComponents(disableStartContract bool, speedrun bool) (string, []di
 					CustomID: "fd_signupStart",
 					Disabled: disableStartContract,
 				},
+				discordgo.Button{
+					Emoji: &discordgo.ComponentEmoji{
+						Name: "♻️",
+					},
+					Label:    "Contract",
+					Style:    discordgo.DangerButton,
+					Disabled: false,
+					CustomID: "fd_delete",
+				},
 			},
 		},
 		discordgo.ActionsRow{

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -99,22 +99,9 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: "Boost Order Management",
+			Content: "Contract created. Use the ♻️Contract button if you have to recycle it.",
 			Flags:   discordgo.MessageFlagsEphemeral,
 			// Buttons and other components are specified in Components field.
-			Components: []discordgo.MessageComponent{
-				// ActionRow is a container of all buttons within the same row.
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.Button{
-							Label:    "Delete Contract",
-							Style:    discordgo.DangerButton,
-							Disabled: false,
-							CustomID: "fd_delete",
-						},
-					},
-				},
-			},
 		},
 	})
 	if err != nil {
@@ -596,4 +583,32 @@ func HandleTokenRemoveCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 	}
 	saveData(Contracts)
 	return str
+}
+
+// HandleContractDelete facilitates the deletion of a channel contract
+func HandleContractDelete(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Delete coop
+	var str = "Contract not found."
+	// if user is contract coordinator
+	contract := FindContract(i.ChannelID)
+
+	if contract != nil {
+
+		if creatorOfContract(contract, i.Member.User.ID) {
+			coopName, err := DeleteContract(s, i.GuildID, i.ChannelID)
+			if err == nil {
+				str = fmt.Sprintf("Contract %s recycled.", coopName)
+			}
+			s.ChannelMessageDelete(i.ChannelID, i.Message.ID)
+		} else {
+			str = "Only the coordinator can recycle this contract."
+		}
+	}
+
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: str,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		}})
 }


### PR DESCRIPTION
Added a new function HandleContractDelete to facilitate the deletion of a channel contract. This function allows the contract coordinator to delete a contract, with validation for permissions.