### PR TITLE
refactor: Update contract choice names to include contract name

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1848,7 +1848,7 @@ func HandleContractAutoComplete(s *discordgo.Session, i *discordgo.InteractionCr
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
 	for _, c := range EggIncContracts {
 		choice := discordgo.ApplicationCommandOptionChoice{
-			Name:  c.ID,
+			Name:  fmt.Sprintf("%s (%s)", c.Name, c.ID),
 			Value: c.ID,
 		}
 		choices = append(choices, &choice)


### PR DESCRIPTION
Update the contract choice names to include both the contract name and the
contract ID for better clarity and distinction.