### PR TITLE
refactor: Update signup count display to include parentheses

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -179,7 +179,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 				sinkIcon := ""
 				if contract.SRData.SinkUserID == b.UserID {
 					sinkIcon = fmt.Sprintf("%s[%d] %s", tokenStr, b.TokensReceived, "🫂")
-					signupCountStr = fmt.Sprint(b.TokensWanted)
+					signupCountStr = fmt.Sprintf("(%d)", b.TokensWanted)
 				}
 				switch b.BoostState {
 				case BoostStateUnboosted:


### PR DESCRIPTION
Increased clarity by updating how the signup count is displayed to include
parentheses for Boost users.