### PR TITLE
feat: Add functionality to automatically purge tracker data after 4 days

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -20,6 +20,7 @@ import (
 	"github.com/divan/num2words"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/track"
 	emutil "github.com/post04/discordgo-emoji-util"
 	"github.com/rs/xid"
 	"google.golang.org/protobuf/proto"
@@ -1767,6 +1768,8 @@ func ArchiveContracts() {
 			// A different task will handle the deletion of the contract
 		}
 	}
+	track.ArchiveTrackerData()
+
 }
 
 // EggIncContract is a raw contract data for Egg Inc

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -210,6 +210,8 @@ func ExecuteCronJob() {
 
 	gocron.Every(1).Day().Do(boost.ArchiveContracts)
 
+	boost.ArchiveContracts()
+
 	<-gocron.Start()
 	log.Print("Exiting cron job")
 }

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -345,6 +345,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 	if td.Linked {
 		footerStr += " Linked contracts will automatically track tokens sent and received through discord message reactions. "
 	}
+	footerStr += " After 4 days any tracker not marked as finished will be purged."
 
 	embed := &discordgo.MessageSend{
 		Embeds: []*discordgo.MessageEmbed{{
@@ -626,4 +627,21 @@ func loadData() (map[string]*tokenValues, error) {
 	}
 	json.Unmarshal(b, &t)
 	return t, nil
+}
+
+// ArchiveTrackerData purges stale tracker data after 4 days
+func ArchiveTrackerData() {
+	if Tokens == nil {
+		return
+	}
+	// For each user, check if the token tracking is older than 3 days
+	// If it is, Finish the data
+	for k, v := range Tokens {
+		for name, tv := range v.Coop {
+			if tv.StartTime.Before(time.Now().Add(-96 * time.Hour)) {
+				delete(Tokens[k].Coop, name)
+			}
+		}
+	}
+	saveData(Tokens)
 }


### PR DESCRIPTION
Added a new function `ArchiveTrackerData` in the track package to purge stale
tracker data that is older than 4 days. This function is called in
`ArchiveContracts` in the boost package and executed daily as a cron job.