### PR TITLE
feat: Add sun emoji bubble to launch message based on event start time

### DIFF
--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -134,9 +134,9 @@ func HandleBoostCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
-				Content:    "This command can only be run in a server.",
-				Flags:      discordgo.MessageFlagsEphemeral,
-				Components: []discordgo.MessageComponent{}},
+				Content: "This command can only be run in a server.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
 		})
 		return
 	}
@@ -148,9 +148,9 @@ func HandleBoostCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content:    str,
-			Flags:      discordgo.MessageFlagsEphemeral,
-			Components: []discordgo.MessageComponent{}},
+			Content: str,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
 	})
 }
 


### PR DESCRIPTION
Add a sun emoji bubble to the launch message if the launch time falls between
the next Sunday at 3pm UTC and the duration after that time. This is to
indicate a special event taking place during that timeframe.