### PR TITLE
fix: Remove check for contract state in ChangePingRole function

### DIFF
--- a/src/boost/boost_change.go
+++ b/src/boost/boost_change.go
@@ -309,11 +309,6 @@ func ChangePingRole(s *discordgo.Session, guildID string, channelID string, user
 		return errors.New(errorNoContract)
 	}
 
-	// return an error if the contract is in the signup state
-	if contract.State == ContractStateSignup {
-		return errors.New(errorContractNotStarted)
-	}
-
 	// return an error if the userID isn't the contract creator
 	if !creatorOfContract(contract, userID) {
 		return errors.New("only the contract creator can change the contract")


### PR DESCRIPTION
Removed the check for contract state in the ChangePingRole function as it is
no longer relevant to the functionality.