### PR TITLE
feat: Add /change-ping-role command

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ const slashSkip string = "skip"
 const slashBoost string = "boost"
 const slashChange string = "change"
 const slashChangeOneBooster string = "change-one-booster"
+const slashChangePingRole string = "change-ping-role"
 const slashUnboost string = "unboost"
 const slashPrune string = "prune"
 const slashJoin string = "join-contract"
@@ -364,6 +365,7 @@ var (
 		boost.GetSlashCalcContractTval(slashCalcContractTval),
 		boost.GetSlashChangeCommand(slashChange),
 		boost.GetSlashChangeOneBoosterCommand(slashChangeOneBooster),
+		boost.GetSlashChangePingRoleCommand(slashChangePingRole),
 		farmerstate.SlashSetEggIncNameCommand(slashSetEggIncName),
 		{
 			Name:        slashBump,
@@ -478,6 +480,9 @@ var (
 		},
 		slashChangeOneBooster: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleChangeOneBoosterCommand(s, i)
+		},
+		slashChangePingRole: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleChangePingRoleCommand(s, i)
 		},
 		slashHelp: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleHelpCommand(s, i)

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -133,6 +133,9 @@ type Booster struct {
 	StartTime        time.Time     // Time Farmer started boost turn
 	EndTime          time.Time     // Time Farmer ended boost turn
 	Duration         time.Duration // Duration of boost
+	RunChickensTime  time.Time     // Time Farmer triggered chicken run reaction
+	RanChickensOn    []string      // Array of users that the farmer ran chickens on
+	BoostTriggerTime time.Time     // Used for time remaining in boost
 }
 
 // LocationData holds server specific Data for a contract


### PR DESCRIPTION
Add a new /change-ping-role command to adjust aspects of a running contract.
This command allows users to change the ping role for the contract.