### PR TITLE
fix: Update launch instructions message

### DIFF
--- a/src/launch/launch_slashcmd.go
+++ b/src/launch/launch_slashcmd.go
@@ -380,7 +380,7 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 	var instr strings.Builder
 	if displaySunInstructions {
-		instr.WriteString("⚠️ Launch before Sunday event will arrive event begins\n")
+		instr.WriteString("⚠️ Launch before Sunday event will arrive after event begins\n")
 	}
 	if displayDubcapInstructions {
 		instr.WriteString("🟢 Arrives during dubcap\n")


### PR DESCRIPTION
Update launch instructions message to clarify that the launch should occur
before the Sunday event starts rather than after it begins.