### PR TITLE
feat: Add functionality to store launch history if option is provided

### DIFF
--- a/src/launch/launch_slashcmd.go
+++ b/src/launch/launch_slashcmd.go
@@ -231,6 +231,7 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if opt, ok := optionMap["chain"]; ok {
 		chainExtended = opt.BoolValue()
 		farmerstate.SetLaunchHistory(userID, chainExtended)
+	} else {
 		chainExtended = farmerstate.GetLaunchHistory(userID)
 	}
 	if opt, ok := optionMap["mission-duration"]; ok {


### PR DESCRIPTION
Storing launch history if "chain" option is provided, else retrieve launch
history for the user.