### PR TITLE
feat: Add /change-planned-start command

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ const slashBoost string = "boost"
 const slashChange string = "change"
 const slashChangeOneBooster string = "change-one-booster"
 const slashChangePingRole string = "change-ping-role"
+const slashChangePlannedStartCommand string = "change-planned-start"
 const slashUnboost string = "unboost"
 const slashPrune string = "prune"
 const slashJoin string = "join-contract"
@@ -370,6 +371,7 @@ var (
 		boost.GetSlashChangeCommand(slashChange),
 		boost.GetSlashChangeOneBoosterCommand(slashChangeOneBooster),
 		boost.GetSlashChangePingRoleCommand(slashChangePingRole),
+		boost.GetSlashChangePlannedStartCommand(slashChangePlannedStartCommand),
 		farmerstate.SlashSetEggIncNameCommand(slashSetEggIncName),
 		{
 			Name:        slashBump,
@@ -487,6 +489,9 @@ var (
 		},
 		slashChangePingRole: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleChangePingRoleCommand(s, i)
+		},
+		slashChangePlannedStartCommand: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleChangePlannedStartCommand(s, i)
 		},
 		slashHelp: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleHelpCommand(s, i)

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -23,7 +23,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 		outputStr = fmt.Sprintf("## %s %s (%s) - %d/%d\n", contract.EggEmoji, contract.Name, contract.CoopID, len(contract.Boosters), contract.CoopSize)
 	}
 
-	if contract.State == ContractStateSignup && contract.PlannedStartTime.After(time.Now()) {
+	if contract.State == ContractStateSignup && contract.PlannedStartTime.After(time.Now()) && contract.PlannedStartTime.Before(time.Now().Add(7*24*time.Hour)) {
 		outputStr += fmt.Sprintf("## Planned Start Time: <t:%d:f>\n", contract.PlannedStartTime.Unix())
 	}
 


### PR DESCRIPTION
Add a new slash command to change the planned start time of a contract. 
The command allows the contract creator to set or clear the planned start time 
within the next 7 days using Discord timestamps.