### PR TITLE
feat: Update username in token tracking and add reactions to contracts

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ const slashTokenRemove string = "token-remove"
 const slashCalcContractTval string = "calc-contract-tval"
 const slashVolunteerSink string = "volunteer-sink"
 const slashVoluntellSink string = "voluntell-sink"
+const slashLinkAlternate string = "link-alternate"
 const slashFun string = "fun"
 
 var integerZeroMinValue float64 = 0.0
@@ -367,6 +368,7 @@ var (
 		},
 		boost.GetSlashVolunteerSink(slashVolunteerSink),
 		boost.GetSlashVoluntellSink(slashVoluntellSink),
+		boost.GetSlasLinkAlternateCommand(slashLinkAlternate),
 		boost.GetSlashCalcContractTval(slashCalcContractTval),
 		boost.GetSlashChangeCommand(slashChange),
 		boost.GetSlashChangeOneBoosterCommand(slashChangeOneBooster),
@@ -390,6 +392,9 @@ var (
 		},
 		slashChange: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleContractAutoComplete(s, i)
+		},
+		slashLinkAlternate: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleLinkAlternateAutoComplete(s, i)
 		},
 		slashTokenRemove: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			if i.GuildID == "" {
@@ -492,6 +497,9 @@ var (
 		},
 		slashChangePlannedStartCommand: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleChangePlannedStartCommand(s, i)
+		},
+		slashLinkAlternate: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleLinkAlternateCommand(s, i)
 		},
 		slashHelp: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleHelpCommand(s, i)

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -236,15 +236,23 @@ func DrawBoostList(s *discordgo.Session, contract *Contract, tokenStr string) st
 	if contract.State == ContractStateStarted {
 		outputStr += "\n"
 		if contract.Speedrun && contract.SRData.SpeedrunStyle == SpeedrunStyleWonky {
-			outputStr += "> " + tokenStr + " when sending tokens to the sink.\n"
+			outputStr += "> " + tokenStr + " when sending tokens to the sink"
+			if len(contract.AltIcons) > 0 {
+				outputStr += ", alts use 🇦-🇿"
+			}
+			outputStr += ".\n"
 			outputStr += "> 🐓 when you're ready for others to run chickens on your farm.\n"
 			outputStr += "> 💰 is used by the Sink to send the requested number of tokens to the booster.\n"
 			outputStr += "> -When active Booster is sent tokens by the sink they are marked as boosted.\n"
 			outputStr += "> -Adjust the number of boost tokens you want by adding a 6️⃣ to 🔟 reaction to the boost list message.\n"
 
 		} else {
-			outputStr += "> Active Booster: " + boostIcon + " when boosting.\n"
-			outputStr += "> Anyone: " + tokenStr + " when sending tokens. ❓ Help.\n"
+			outputStr += "> Active Booster: " + boostIcon + " when boosting. \n"
+			outputStr += "> Anyone: " + tokenStr + " when sending tokens "
+			if len(contract.AltIcons) > 0 {
+				outputStr += ", alts use 🇦-🇿"
+			}
+			outputStr += ". ❓ Help.\n"
 		}
 		if contract.CoopSize != len(contract.Order) {
 			outputStr += "> Use pinned message or add 🧑‍🌾 reaction to join this list and set boost " + tokenStr + " wanted.\n"

--- a/src/boost/boost_slashcalctval.go
+++ b/src/boost/boost_slashcalctval.go
@@ -137,7 +137,7 @@ func calculateTokenValue(startTime time.Time, duration time.Duration, details bo
 		fmt.Fprintf(&builder, "**Tokens Sent: %d for %4.3f**\n", len(booster.Sent), sentValue)
 		if details {
 			for i := range booster.Sent {
-				fmt.Fprintf(&builder, "> %d: %s  %6.3f\n", i+1, booster.Sent[i].Time.Sub(startTime).Round(time.Second), booster.Sent[i].Value)
+				fmt.Fprintf(&builder, "> %d: %s  %6.3f %16s\n", i+1, booster.Sent[i].Time.Sub(startTime).Round(time.Second), booster.Sent[i].Value, booster.Sent[i].UserID)
 			}
 		}
 	}
@@ -149,7 +149,7 @@ func calculateTokenValue(startTime time.Time, duration time.Duration, details bo
 		fmt.Fprintf(&builder, "**Token Received: %d for %4.3f**\n", len(booster.Received), receivedValue)
 		if details {
 			for i := range booster.Received {
-				fmt.Fprintf(&builder, "> %d: %s  %6.3f\n", i+1, booster.Received[i].Time.Sub(startTime).Round(time.Second), booster.Received[i].Value)
+				fmt.Fprintf(&builder, "> %d: %s  %6.3f %16s\n", i+1, booster.Received[i].Time.Sub(startTime).Round(time.Second), booster.Received[i].Value, booster.Received[i].UserID)
 			}
 		}
 	}


### PR DESCRIPTION
Updated the username in token tracking to show the actual username instead
of the user ID. Added functionality to add multiple reactions to contract
messages based on contract state.