### PR TITLE
refactor: Improve logic for finding the most recent boost time among user and alts

### DIFF
--- a/src/boost/boost_reactions.go
+++ b/src/boost/boost_reactions.go
@@ -184,15 +184,15 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 		if r.Emoji.Name == "🐓" {
 			// Indicate that a farmer is ready for chicken runs
 			userID := r.UserID
-			// Check if the user has any alts
 			if len(contract.Boosters[r.UserID].Alts) > 0 {
-				// Find the most recent boost time among the user and their alts
-				mostRecentTime := contract.Boosters[userID].EndTime
-				for _, altID := range contract.Boosters[r.UserID].Alts {
-					alt := contract.Boosters[altID]
-					if alt.EndTime.After(mostRecentTime) {
-						mostRecentTime = alt.EndTime
-						userID = altID
+				ids := append(contract.Boosters[r.UserID].Alts, r.UserID)
+				for _, id := range contract.Order {
+					if slices.Index(ids, id) != -1 {
+						alt := contract.Boosters[id]
+						if alt.BoostState == BoostStateBoosted && alt.RunChickensTime.IsZero() {
+							userID = id
+							break
+						}
 					}
 				}
 			}

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -479,19 +479,18 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 			// Indicate that a farmer is ready for chicken runs
 
 			userID := r.UserID
-			// Check if the user has any alts
 			if len(contract.Boosters[r.UserID].Alts) > 0 {
-				// Find the most recent boost time among the user and their alts
-				mostRecentTime := contract.Boosters[userID].EndTime
-				for _, altID := range contract.Boosters[r.UserID].Alts {
-					alt := contract.Boosters[altID]
-					if alt.EndTime.After(mostRecentTime) {
-						mostRecentTime = alt.EndTime
-						userID = altID
+				ids := append(contract.Boosters[r.UserID].Alts, r.UserID)
+				for _, id := range contract.Order {
+					if slices.Index(ids, id) != -1 {
+						alt := contract.Boosters[id]
+						if alt.BoostState == BoostStateBoosted && alt.RunChickensTime.IsZero() {
+							userID = id
+							break
+						}
 					}
 				}
 			}
-
 			contract.Boosters[userID].RunChickensTime = time.Now()
 			str := fmt.Sprintf("%s **%s** is ready for chicken runs, check for incoming trucks before visiting.", contract.Location[0].ChannelPing, contract.Boosters[userID].Mention)
 			var data discordgo.MessageSend


### PR DESCRIPTION
Added a more efficient way to find the most recent boost time among users and their alts by iterating through the contract order and checking for boosted and idle users.