### PR TITLE
fix: Update AddFarmerToContract function to set nickname if empty

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -646,6 +646,9 @@ func AddFarmerToContract(s *discordgo.Session, contract *Contract, guildID strin
 				}
 				b.Unique = gm.User.String()
 			}
+			if b.Nick == "" {
+				b.Nick = b.Name
+			}
 		}
 
 		b.GuildID = guildID


### PR DESCRIPTION
Set the nickname to the name if it is empty in the AddFarmerToContract function.