### PR TITLE
refactor: Use strings.ReplaceAll in printResponse function

### DIFF
--- a/src/notok/notok.go
+++ b/src/notok/notok.go
@@ -222,8 +222,6 @@ func getStringFromGoogleGemini(text string) (string, error) {
 		return "", errors.New(respStr)
 	}
 
-	respStr = strings.ReplaceAll(respStr, "widget", "token")
-
 	return printResponse(resp, false), nil
 }
 
@@ -264,6 +262,9 @@ func printResponse(resp *genai.GenerateContentResponse, logit bool) string {
 			}
 		}
 	}
+
+	str = strings.ReplaceAll(str, "widget", "token")
+
 	return str
 }
 


### PR DESCRIPTION
Simplify code by using strings.ReplaceAll to replace "widget" with "token"
in the printResponse function.