### PR TITLE
feat: Add formatted duration to chainString in HandleLaunchHelper

### DIFF
--- a/src/launch/launch_slashcmd.go
+++ b/src/launch/launch_slashcmd.go
@@ -419,7 +419,7 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 					exDuration, _ := str2duration.ParseDuration(minutesStr)
 
 					chainLaunchTime := launchTime.Add(exDuration)
-					chainString = fmt.Sprintf(" +next EX return <t:%d:t>", chainLaunchTime.Unix())
+					chainString = fmt.Sprintf(" +exHen (%s) <t:%d:t>", fmtDuration(exDuration), chainLaunchTime.Unix())
 					if fasterMissions != 1.0 {
 						// Calculate an additional duration
 						minutesStr := fmt.Sprintf("%dm", int(exhenDuration.Minutes()*ftlMult*fasterMissions))
@@ -429,7 +429,7 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 						exDuration, _ := str2duration.ParseDuration(minutesStr)
 
 						chainLaunchTime = chainLaunchTime.Add(exDuration)
-						chainString += fmt.Sprintf(" +return <t:%d:t>", chainLaunchTime.Unix())
+						chainString += fmt.Sprintf(" +exHen (%s) <t:%d:t>", fmtDuration(exDuration), chainLaunchTime.Unix())
 					}
 				}
 


### PR DESCRIPTION
Add the formatted duration of the EX Hen to the chainString in the HandleLaunchHelper
function to improve readability and provide additional information to users.