### PR TITLE
feat: Add parameter to ArchiveContracts to handle Discord session

### DIFF
--- a/main.go
+++ b/main.go
@@ -776,7 +776,7 @@ func main() {
 	*/
 
 	// Start our CRON job to grab Egg Inc contract data from the Carpet github repository
-	go tasks.ExecuteCronJob()
+	go tasks.ExecuteCronJob(s)
 
 	s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
 		log.Printf("Ready message for: %v#%v  SessID:%v", s.State.User.Username, s.State.User.Discriminator, r.SessionID)

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1495,7 +1495,7 @@ func reorderBoosters(contract *Contract) {
 }
 
 // ArchiveContracts will set a contract state to Archive if it is older than 5 days
-func ArchiveContracts() {
+func ArchiveContracts(s *discordgo.Session) {
 	currentTime := time.Now()
 	for _, contract := range Contracts {
 		if currentTime.Sub(contract.StartTime) > 5*24*time.Hour {
@@ -1503,7 +1503,7 @@ func ArchiveContracts() {
 			// A different task will handle the deletion of the contract
 		}
 	}
-	track.ArchiveTrackerData()
+	track.ArchiveTrackerData(s)
 
 }
 

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -225,7 +225,7 @@ func downloadEggIncData(url string, filename string) bool {
 }
 
 // ExecuteCronJob runs the cron jobs for the bot
-func ExecuteCronJob() {
+func ExecuteCronJob(s *discordgo.Session) {
 	if !downloadEggIncData(eggIncContractsURL, eggIncContractsFile) {
 		boost.LoadContractData(eggIncContractsFile)
 	}
@@ -261,7 +261,9 @@ func ExecuteCronJob() {
 		gocron.Every(1).Day().At(t).Do(crondownloadEggIncData)
 	}
 
-	gocron.Every(1).Day().Do(boost.ArchiveContracts)
+	gocron.Every(1).Day().Do(boost.ArchiveContracts, s)
+
+	gocron.Every(1).Minute().Do(boost.ArchiveContracts, s)
 
 	<-gocron.Start()
 	log.Print("Exiting cron job")

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -263,8 +263,6 @@ func ExecuteCronJob(s *discordgo.Session) {
 
 	gocron.Every(1).Day().Do(boost.ArchiveContracts, s)
 
-	gocron.Every(1).Minute().Do(boost.ArchiveContracts, s)
-
 	<-gocron.Start()
 	log.Print("Exiting cron job")
 }

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -606,7 +606,7 @@ func loadData() (map[string]*tokenValues, error) {
 }
 
 // ArchiveTrackerData purges stale tracker data after 4 days
-func ArchiveTrackerData() {
+func ArchiveTrackerData(s *discordgo.Session) {
 	if Tokens == nil {
 		return
 	}
@@ -614,7 +614,10 @@ func ArchiveTrackerData() {
 	// If it is, Finish the data
 	for k, v := range Tokens {
 		for name, tv := range v.Coop {
-			if tv.StartTime.Before(time.Now().Add(-96 * time.Hour)) {
+			if tv.StartTime.Before(time.Now().Add(-72 * time.Hour)) {
+				s.ChannelMessageDelete(tv.UserChannelID, tv.TokenMessageID)
+				embed := getTokenTrackingEmbed(tv, true)
+				s.ChannelMessageSendComplex(tv.UserChannelID, embed)
 				delete(Tokens[k].Coop, name)
 			}
 		}


### PR DESCRIPTION
Add parameter to ArchiveContracts function in boost.go and tasks.go to include
a Discord session for handling Discord messages related to token tracking
and contract archiving. Update related functions in track.go to ensure correct
functionality with Discord session.