### PR TITLE
feat: Fix condition comparison for launch time in HandleLaunchHelper

### DIFF
--- a/src/launch/launch_slashcmd.go
+++ b/src/launch/launch_slashcmd.go
@@ -413,7 +413,7 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 					exhenDuration, _ := str2duration.ParseDuration("4d")
 					minutesStr := fmt.Sprintf("%dm", int(exhenDuration.Minutes()*ftlMult*fasterMissions))
-					if fastDuration != nil && arrivalTime.After(fastDuration.EndTime) {
+					if fastDuration != nil && launchTime.After(fastDuration.EndTime) {
 						minutesStr = fmt.Sprintf("%dm", int(exhenDuration.Minutes()*ftlMult*1.0))
 					}
 					exDuration, _ := str2duration.ParseDuration(minutesStr)


### PR DESCRIPTION
Refactor the condition to check if launch time is after the end time of the
fast duration instead of arrival time. This ensures correct calculation of
minutes for the mission duration.