### PR TITLE
refactor: Update admin command authorization logic and settings naming

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,10 +25,10 @@ import (
 
 // Admin Slash Command Constants
 const boostBotHomeGuild string = "766330702689992720"
-const slashAdminContractsList string = "contract-list"
-const slashAdminContractFinish string = "contract-finish"
-const slashAdminBotSettings string = "bot-settings"
-const slashReloadContracts string = "reload-contracts"
+const slashAdminContractsList string = "admin-contract-list"
+const slashAdminContractFinish string = "admin-contract-finish"
+const slashAdminBotSettings string = "admin-bot-settings"
+const slashReloadContracts string = "admin-reload-contracts"
 
 // Slash Command Constants
 const slashContract string = "contract"
@@ -110,7 +110,7 @@ var (
 	GuildID        = flag.String("guild", "", "Test guild ID")
 	BotToken       = flag.String("token", "", "Bot access token")
 	AppID          = flag.String("app", "", "Application ID")
-	RemoveCommands = flag.Bool("rmcmd", false, "Remove all commands after shutdowning or not")
+	RemoveCommands = flag.Bool("rmcmd", true, "Remove all commands after shutdowning or not")
 
 	adminCommands = []*discordgo.ApplicationCommand{
 		{
@@ -125,18 +125,6 @@ var (
 					Type:        discordgo.ApplicationCommandOptionString,
 					Name:        "contract-hash",
 					Description: "Hash of the contract to finish",
-					Required:    true,
-				},
-			},
-		},
-		{
-			Name:        slashAdminBotSettings,
-			Description: "Set various bot settings",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Type:        discordgo.ApplicationCommandOptionBoolean,
-					Name:        "debug-logging",
-					Description: "Enable or disable debug logging",
 					Required:    true,
 				},
 			},
@@ -832,7 +820,7 @@ func main() {
 
 	// Admin Commands exist only for the BoostBot Home Guild
 	for i, v := range adminCommands {
-		cmd, err := s.ApplicationCommandCreate(s.State.User.ID, boostBotHomeGuild, v)
+		cmd, err := s.ApplicationCommandCreate(s.State.User.ID, "", v)
 		if err != nil {
 			log.Printf("Cannot create '%v' command: %v", v.Name, err)
 		}

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -409,7 +409,7 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 		contract.StartTime = time.Now()
 		contract.ChickenRunEmoji = findBoostBotGuildEmoji(s, "icon_chicken_run", true)
 
-		for _, el := range adminUsers {
+		for _, el := range AdminUsers {
 			if slices.Index(contract.CreatorID, el) == -1 {
 				contract.CreatorID = append(contract.CreatorID, el) // Add admin users to the contract
 			}

--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -11,7 +11,8 @@ import (
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 )
 
-var adminUsers = []string{
+// AdminUsers is a list of users who are allowed to use admin commands
+var AdminUsers = []string{
 	"238786501700222986", // RAIYC
 	"393477262412087319", // Tbone
 	"430186990260977665", // aggie
@@ -34,8 +35,15 @@ func HandleAdminContractFinish(s *discordgo.Session, i *discordgo.InteractionCre
 		contractHash = strings.TrimSpace(opt.StringValue())
 	}
 
+	userID := ""
+	if i.GuildID == "" {
+		userID = i.User.ID
+	} else {
+		userID = i.Member.User.ID
+	}
+
 	// Only allow command if users is in the admin list
-	if slices.Index(adminUsers, i.Member.User.ID) == -1 {
+	if slices.Index(AdminUsers, userID) == -1 {
 		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
@@ -68,6 +76,24 @@ func HandleAdminContractList(s *discordgo.Session, i *discordgo.InteractionCreat
 		str = err.Error()
 	}
 
+	userID := ""
+	if i.GuildID == "" {
+		userID = i.User.ID
+	} else {
+		userID = i.Member.User.ID
+	}
+
+	// Only allow command if users is in the admin list
+	if slices.Index(AdminUsers, userID) == -1 {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content:    "You are not authorized to use this command.",
+				Flags:      discordgo.MessageFlagsEphemeral,
+				Components: []discordgo.MessageComponent{}},
+		})
+		return
+	}
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -28,6 +29,25 @@ var lastEventUpdate time.Time
 // HandleReloadContractsCommand will handle the /reload command
 func HandleReloadContractsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	str := "No updated Egg Inc contract data available.\n"
+
+	userID := ""
+	if i.GuildID == "" {
+		userID = i.User.ID
+	} else {
+		userID = i.Member.User.ID
+	}
+
+	// Only allow command if users is in the admin list
+	if slices.Index(boost.AdminUsers, userID) == -1 {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content:    "You are not authorized to use this command.",
+				Flags:      discordgo.MessageFlagsEphemeral,
+				Components: []discordgo.MessageComponent{}},
+		})
+		return
+	}
 
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,


### PR DESCRIPTION
 - Refactored admin command authorization logic to check user ID in AdminUsers instead of adminUsers
 - Renamed admin-related settings to have 'admin-' prefix for clarity and consistency
 - Removed slashAdminBotSettings application command due to redundancy