### PR TITLE
refactor: Update AdminUsers variable to be populated from config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func init() {
 	err := config.ReadConfig("./.config.json")
 
 	if err != nil {
+		boost.AdminUsers = config.AdminUsers
 		log.Println(err.Error())
 		return
 	}

--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -12,16 +12,7 @@ import (
 )
 
 // AdminUsers is a list of users who are allowed to use admin commands
-var AdminUsers = []string{
-	"238786501700222986", // RAIYC
-	"184063956539670528", // Halcyon
-	"393477262412087319", // Tbone
-	"430186990260977665", // aggie
-	"662685289885466672", // DipDip
-	"429540887383506954", // Hypnojustice
-	"899945319582822400", // LousyCurve
-	"322180654773305356", // Scottsaxman
-}
+var AdminUsers = []string{}
 
 // HandleAdminContractFinish is called when the contract is complete
 func HandleAdminContractFinish(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/src/boost/boost_teamwork.go
+++ b/src/boost/boost_teamwork.go
@@ -87,7 +87,7 @@ func HandleTeamworkEvalCommand(s *discordgo.Session, i *discordgo.InteractionCre
 	}
 
 	isAdmin := false
-	for _, el := range AdminUsers[:3] {
+	for _, el := range config.AdminUsers[:4] {
 		if el == userID {
 			isAdmin = true
 			break

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -15,17 +15,19 @@ var (
 	GoogleAPIKey   string
 	AdminUserID    string
 	EIUserID       string
+	AdminUsers     []string
 	config         *configStruct
 )
 
 type configStruct struct {
-	DiscordToken   string `json:"DiscordToken"`
-	DiscordAppID   string `json:"DiscordAppID"`
-	DiscordGuildID string `json:"DiscordGuildID"`
-	OpenAIKey      string `json:"OpenAIKey"`
-	GoogleAPIKey   string `json:"GoogleAPIKey"`
-	AdminUserID    string `json:"AdminUserId"`
-	EIUserID       string `json:"EIUserId"`
+	DiscordToken   string   `json:"DiscordToken"`
+	DiscordAppID   string   `json:"DiscordAppID"`
+	DiscordGuildID string   `json:"DiscordGuildID"`
+	OpenAIKey      string   `json:"OpenAIKey"`
+	GoogleAPIKey   string   `json:"GoogleAPIKey"`
+	AdminUserID    string   `json:"AdminUserId"`
+	EIUserID       string   `json:"EIUserId"`
+	AdminUsers     []string `json:"AdminUsers"`
 }
 
 // ReadConfig will load the configuration files for API tokens.
@@ -53,6 +55,7 @@ func ReadConfig(cfgFile string) error {
 	GoogleAPIKey = config.GoogleAPIKey
 	AdminUserID = config.AdminUserID
 	EIUserID = config.EIUserID
+	AdminUsers = config.AdminUsers
 
 	return nil
 }


### PR DESCRIPTION
This commit updates the AdminUsers variable to be populated from the config file
instead of being hardcoded in the boost_admin.go file. AdminUsers is now an
empty slice in boost_admin.go and is assigned the value from config.AdminUsers
in main.go and boost_teamwork.go.