### PR TITLE
refactor: Ignore error return values in ChannelMessageSend and MessageReactionAdd functions

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -266,8 +266,8 @@ func DeleteContract(s *discordgo.Session, guildID string, channelID string) (str
 
 	for _, el := range contract.Location {
 		if s != nil {
-			s.ChannelMessageDelete(el.ChannelID, el.ListMsgID)
-			s.ChannelMessageDelete(el.ChannelID, el.ReactionID)
+			_ = s.ChannelMessageDelete(el.ChannelID, el.ListMsgID)
+			_ = s.ChannelMessageDelete(el.ChannelID, el.ReactionID)
 		}
 	}
 	delete(Contracts, coopHash)
@@ -450,7 +450,7 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 // AddBoostTokensInteraction handles the interactions responses for AddBoostTokens
 func AddBoostTokensInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, setCountWant int, countWantAdjust int) {
 	var str string
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: "Processing request...",
@@ -465,7 +465,7 @@ func AddBoostTokensInteraction(s *discordgo.Session, i *discordgo.InteractionCre
 		str = fmt.Sprintf("Adjusted. Tokens Wanted %d, Received %d", tSent, tRecv)
 	}
 
-	s.FollowupMessageCreate(i.Interaction, true,
+	_, _ = s.FollowupMessageCreate(i.Interaction, true,
 		&discordgo.WebhookParams{
 			Content: str,
 		})
@@ -636,7 +636,7 @@ func AddContractMember(s *discordgo.Session, guildID string, channelID string, o
 				listStr = "Sign-up"
 			}
 			var str = fmt.Sprintf("%s was added to the %s List by %s", guest, listStr, operator)
-			s.ChannelMessageSend(loc.ChannelID, str)
+			_, _ = s.ChannelMessageSend(loc.ChannelID, str)
 		}
 	}
 
@@ -994,7 +994,7 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 			if err == nil {
 				loc.ListMsgID = msg.ID
 			} else {
-				s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
+				_ = s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
 				msg, _ := s.ChannelMessageSend(loc.ChannelID, outputStr)
 				SetListMessageID(contract, loc.ChannelID, msg.ID)
 			}
@@ -1007,7 +1007,7 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 					contentStr, comp := GetSignupComponents(true, contract.Speedrun) // True to get a disabled start button
 					msg.SetContent(contentStr)
 					msg.Components = &comp
-					s.ChannelMessageEditComplex(msg)
+					_, _ = s.ChannelMessageEditComplex(msg)
 				}
 			}
 		}
@@ -1077,7 +1077,7 @@ func RedrawBoostList(s *discordgo.Session, guildID string, channelID string) err
 	// Edit the boost list in place
 	for _, loc := range contract.Location {
 		if loc.GuildID == guildID && loc.ChannelID == channelID {
-			s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
+			_ = s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
 			var data discordgo.MessageSend
 			var am discordgo.MessageAllowedMentions
 			data.Content = DrawBoostList(s, contract, loc.TokenStr)
@@ -1109,7 +1109,7 @@ func refreshBoostListMessage(s *discordgo.Session, contract *Contract) {
 				contentStr, comp := GetSignupComponents(false, contract.Speedrun) // True to get a disabled start button
 				msg.SetContent(contentStr)
 				msg.Components = &comp
-				s.ChannelMessageEditComplex(msg)
+				_, _ = s.ChannelMessageEditComplex(msg)
 			}
 		}
 
@@ -1136,27 +1136,26 @@ func addContractReactions(s *discordgo.Session, contract *Contract, channelID st
 	}
 
 	if contract.State == ContractStateStarted {
-		s.MessageReactionAdd(channelID, messageID, boostIconReaction) // Booster
-		s.MessageReactionAdd(channelID, messageID, tokenStr)          // Token Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, boostIconReaction) // Booster
+		_ = s.MessageReactionAdd(channelID, messageID, tokenStr)          // Token Reaction
 		for _, el := range contract.AltIcons {
-			s.MessageReactionAdd(channelID, messageID, el)
+			_ = s.MessageReactionAdd(channelID, messageID, el)
 		}
-		s.MessageReactionAdd(channelID, messageID, "🔃")  // Swap
-		s.MessageReactionAdd(channelID, messageID, "⤵️") // Last
-		s.MessageReactionAdd(channelID, messageID, "🐓")  // Want Chicken Run
+		_ = s.MessageReactionAdd(channelID, messageID, "🔃")  // Swap
+		_ = s.MessageReactionAdd(channelID, messageID, "⤵️") // Last
+		_ = s.MessageReactionAdd(channelID, messageID, "🐓")  // Want Chicken Run
 	}
 	if contract.State == ContractStateWaiting || contract.State == ContractStateCompleted {
 		if contract.VolunteerSink != "" {
-			s.MessageReactionAdd(channelID, messageID, tokenStr) // Token Reaction
+			_ = s.MessageReactionAdd(channelID, messageID, tokenStr) // Token Reaction
 			for _, el := range contract.AltIcons {
-				s.MessageReactionAdd(channelID, messageID, el)
+				_ = s.MessageReactionAdd(channelID, messageID, el)
 			}
 		}
-		s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
-		//s.MessageReactionAdd(channelID, messageID, "🏁") // Finish
+		_ = s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
 	}
 
-	s.MessageReactionAdd(channelID, messageID, "❓") // Finish
+	_ = s.MessageReactionAdd(channelID, messageID, "❓") // Finish
 }
 
 func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bool) {
@@ -1174,9 +1173,9 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 		} else {
 			// Unpin message once the contract is completed
 			if contract.State == ContractStateArchive {
-				s.ChannelMessageUnpin(loc.ChannelID, loc.ReactionID)
+				_ = s.ChannelMessageUnpin(loc.ChannelID, loc.ReactionID)
 			}
-			s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
+			_ = s.ChannelMessageDelete(loc.ChannelID, loc.ListMsgID)
 
 			// Compose the message without a Ping
 			var data discordgo.MessageSend
@@ -1240,7 +1239,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 
 		// Sending the update message
 		if !contract.Speedrun {
-			s.ChannelMessageSend(loc.ChannelID, str)
+			_, _ = s.ChannelMessageSend(loc.ChannelID, str)
 		} else if !drawn {
 			RedrawBoostList(s, loc.GuildID, loc.ChannelID)
 		}

--- a/src/boost/boost_change.go
+++ b/src/boost/boost_change.go
@@ -399,7 +399,7 @@ func HandleChangePingRoleCommand(s *discordgo.Session, i *discordgo.InteractionC
 				}
 				loc.ChannelPing = newRole
 				str = "Ping role changed to " + newRole
-				s.ChannelMessageSend(i.ChannelID, str)
+				_, _ = s.ChannelMessageSend(i.ChannelID, str)
 				break
 			}
 		}

--- a/src/boost/boost_datastore.go
+++ b/src/boost/boost_datastore.go
@@ -14,7 +14,10 @@ var dataStore *diskv.Diskv
 // SaveAllData will remove a token from the Contracts
 func SaveAllData() {
 	log.Print("Saving contact data")
-	saveData(Contracts)
+	err := saveData(Contracts)
+	if err != nil {
+		log.Print("SaveAllData error saving Contracts:", err)
+	}
 }
 
 func initDataStore() {
@@ -48,12 +51,8 @@ func InverseTransform(pathKey *diskv.PathKey) (key string) {
 }
 
 func saveData(c map[string]*Contract) error {
-	//diskmutex.Lock()
 	b, _ := json.Marshal(c)
-	dataStore.Write("EggsBackup", b)
-
-	//diskmutex.Unlock()
-	return nil
+	return dataStore.Write("EggsBackup", b)
 }
 
 func saveEndData(c *Contract) error {

--- a/src/boost/boost_reactions.go
+++ b/src/boost/boost_reactions.go
@@ -171,7 +171,7 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 					// Move Booster position is 1 based, so we need to add 2 to the current position
 					err := MoveBooster(s, r.GuildID, r.ChannelID, contract.CreatorID[0], r.UserID, contract.BoostPosition+2, true)
 					if err == nil {
-						s.ChannelMessageSend(r.ChannelID, contract.Boosters[r.UserID].Name+" expressed a desire to go next!")
+						_, _ = s.ChannelMessageSend(r.ChannelID, contract.Boosters[r.UserID].Name+" expressed a desire to go next!")
 						returnVal = "!gonow"
 					}
 				}
@@ -211,7 +211,7 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 				var data discordgo.MessageSend
 				data.Content = str
 				msg, _ := s.ChannelMessageSendComplex(location.ChannelID, &data)
-				s.MessageReactionAdd(msg.ChannelID, msg.ID, contract.ChickenRunEmoji) // Indicate Chicken Run
+				_ = s.MessageReactionAdd(msg.ChannelID, msg.ID, contract.ChickenRunEmoji) // Indicate Chicken Run
 			}
 			redraw = true
 		}
@@ -286,7 +286,7 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 	err = s.MessageReactionRemove(r.ChannelID, r.MessageID, emojiName, r.UserID)
 	if err != nil {
 		fmt.Println(err, emojiName)
-		s.MessageReactionRemove(r.ChannelID, r.MessageID, r.Emoji.Name, r.UserID)
+		_ = s.MessageReactionRemove(r.ChannelID, r.MessageID, r.Emoji.Name, r.UserID)
 	}
 
 	if redraw {
@@ -306,7 +306,7 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 			outputStr += "Reaction of 🐓 when you're ready for others to run chickens on your farm.\n"
 			outputStr += "Anyone can add a 🚽 reaction to express your urgency to boost next.\n"
 			outputStr += "Additional help through the **/help** command.\n"
-			s.ChannelMessageSend(loc.ChannelID, outputStr)
+			_, _ = s.ChannelMessageSend(loc.ChannelID, outputStr)
 		}
 	}
 

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -54,7 +54,7 @@ func UpdateThreadName(s *discordgo.Session, contract *Contract) {
 		if err == nil {
 
 			if ch.IsThread() {
-				s.ChannelEdit(loc.ChannelID, &discordgo.ChannelEdit{
+				_, _ = s.ChannelEdit(loc.ChannelID, &discordgo.ChannelEdit{
 					Name: builder.String(),
 				})
 			}
@@ -152,7 +152,7 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 				thread, err := s.ThreadStart(ChannelID, builder.String(), discordgo.ChannelTypeGuildPublicThread, 60*24)
 				if err == nil {
 					ChannelID = thread.ID
-					s.ThreadJoin(i.Member.User.ID)
+					_ = s.ThreadJoin(i.Member.User.ID)
 				} else {
 					log.Print(err)
 				}
@@ -205,7 +205,7 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 			log.Print(err)
 		} else {
 			SetReactionID(contract, msg.ChannelID, reactionMsg.ID)
-			s.ChannelMessagePin(msg.ChannelID, reactionMsg.ID)
+			_ = s.ChannelMessagePin(msg.ChannelID, reactionMsg.ID)
 		}
 	} else {
 		log.Print(err)
@@ -579,7 +579,7 @@ func HandleContractDelete(s *discordgo.Session, i *discordgo.InteractionCreate) 
 				str = fmt.Sprintf("Contract %s recycled.", coopName)
 			}
 			for _, loc := range contract.Location {
-				s.ChannelMessageUnpin(loc.ChannelID, loc.ReactionID)
+				_ = s.ChannelMessageUnpin(loc.ChannelID, loc.ReactionID)
 			}
 			s.ChannelMessageDelete(i.ChannelID, i.Message.ID)
 		} else {

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -262,29 +262,28 @@ func drawSpeedrunCRT(contract *Contract, tokenStr string) string {
 
 func addSpeedrunContractReactions(s *discordgo.Session, contract *Contract, channelID string, messageID string, tokenStr string) {
 	if contract.SRData.SpeedrunState == SpeedrunStateCRT {
-		s.MessageReactionAdd(channelID, messageID, tokenStr) // Token Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, tokenStr) // Token Reaction
 		for _, el := range contract.AltIcons {
-			s.MessageReactionAdd(channelID, messageID, el)
+			_ = s.MessageReactionAdd(channelID, messageID, el)
 		}
-		s.MessageReactionAdd(channelID, messageID, "✅") // Run Reaction
-		s.MessageReactionAdd(channelID, messageID, "🚚") // Truck Reaction
-		s.MessageReactionAdd(channelID, messageID, "🦵") // Kick Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, "✅") // Run Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, "🚚") // Truck Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, "🦵") // Kick Reaction
 	}
 	if contract.SRData.SpeedrunState == SpeedrunStateBoosting {
-		s.MessageReactionAdd(channelID, messageID, tokenStr) // Send token to Sink
+		_ = s.MessageReactionAdd(channelID, messageID, tokenStr) // Send token to Sink
 		for _, el := range contract.AltIcons {
-			s.MessageReactionAdd(channelID, messageID, el)
+			_ = s.MessageReactionAdd(channelID, messageID, el)
 		}
-		s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
-		s.MessageReactionAdd(channelID, messageID, "💰") // Sink sent requested number of tokens to booster
+		_ = s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
+		_ = s.MessageReactionAdd(channelID, messageID, "💰") // Sink sent requested number of tokens to booster
 	}
 	if contract.SRData.SpeedrunState == SpeedrunStatePost {
-		s.MessageReactionAdd(channelID, messageID, tokenStr) // Send token to Sink
+		_ = s.MessageReactionAdd(channelID, messageID, tokenStr) // Send token to Sink
 		for _, el := range contract.AltIcons {
-			s.MessageReactionAdd(channelID, messageID, el)
+			_ = s.MessageReactionAdd(channelID, messageID, el)
 		}
-		s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
-		//s.MessageReactionAdd(channelID, messageID, "🏁") // Run Reaction
+		_ = s.MessageReactionAdd(channelID, messageID, "🐓") // Want Chicken Run
 	}
 }
 
@@ -377,7 +376,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 					contract.SRData.ChickenRunCheckMsgID = ""
 
 					str := fmt.Sprintf("All players have run chickens. **%s** should now react with 🦵 then start to kick all farmers.", contract.Boosters[contract.SRData.SinkUserID].Mention)
-					s.ChannelMessageSend(r.ChannelID, str)
+					_, _ = s.ChannelMessageSend(r.ChannelID, str)
 				}
 			}
 			// Indicate that the farmer has completed running chickens
@@ -387,7 +386,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 			keepReaction = true
 			// Indicate that the farmer has a truck incoming
 			str := fmt.Sprintf("Truck arriving for **%s**. The sink may or may not pause kicks.", contract.Boosters[r.UserID].Mention)
-			s.ChannelMessageSend(contract.Location[0].ChannelID, str)
+			_, _ = s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 		}
 
 		idx := slices.Index(contract.Boosters[r.UserID].Alts, contract.SRData.SpeedrunStarterUserID)
@@ -403,7 +402,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				str := "**Starting to kick users.** Swap shiny artifacts if you need to force a server sync.\n"
 				str += contract.Boosters[contract.SRData.SpeedrunStarterUserID].Mention + " will react here with 💃 after kicks to advance the tango."
 				msg, _ := s.ChannelMessageSend(contract.Location[0].ChannelID, str)
-				s.MessageReactionAdd(contract.Location[0].ChannelID, msg.ID, "💃") // Tango Reaction
+				_ = s.MessageReactionAdd(contract.Location[0].ChannelID, msg.ID, "💃") // Tango Reaction
 				SetReactionID(contract, contract.Location[0].ChannelID, msg.ID)
 				contract.SRData.LegReactionMessageID = msg.ID
 				if contract.SRData.ChickenRunCheckMsgID != "" {
@@ -426,7 +425,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				contract.Boosters[contract.Order[contract.BoostPosition]].BoostState = BoostStateTokenTime
 				contract.Boosters[contract.Order[contract.BoostPosition]].StartTime = time.Now()
 				//}
-				s.ChannelMessageSend(contract.Location[0].ChannelID, str)
+				_, _ = s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 				sendNextNotification(s, contract, true)
 			}
 		}
@@ -476,7 +475,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 				}
 				str += fmt.Sprintf("you've been sent %d tokens to boost with!", b.TokensWanted)
 
-				s.ChannelMessageSend(contract.Location[0].ChannelID, str)
+				_, _ = s.ChannelMessageSend(contract.Location[0].ChannelID, str)
 
 				redraw = false
 			}
@@ -505,7 +504,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 			var data discordgo.MessageSend
 			data.Content = str
 			msg, _ := s.ChannelMessageSendComplex(contract.Location[0].ChannelID, &data)
-			s.MessageReactionAdd(msg.ChannelID, msg.ID, contract.ChickenRunEmoji) // Indicate Chicken Run
+			_ = s.MessageReactionAdd(msg.ChannelID, msg.ID, contract.ChickenRunEmoji) // Indicate Chicken Run
 			keepReaction = true
 			redraw = true
 		}
@@ -529,7 +528,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 
 	// Remove extra added emoji
 	if !keepReaction {
-		s.MessageReactionRemove(r.ChannelID, r.MessageID, emojiName, r.UserID)
+		_ = s.MessageReactionRemove(r.ChannelID, r.MessageID, emojiName, r.UserID)
 	}
 
 	if redraw {

--- a/src/notok/notok.go
+++ b/src/notok/notok.go
@@ -107,7 +107,7 @@ func Notok(s *discordgo.Session, i *discordgo.InteractionCreate, cmd int64, text
 					Content: fmt.Sprintf("Success\nResponse time: %s", time.Since(currentStartTime).Round(time.Second).String()),
 				},
 			)
-			s.ChannelMessageSend(i.ChannelID, wishStr)
+			_, _ = s.ChannelMessageSend(i.ChannelID, wishStr)
 			lastWish = wishStr
 		}
 	} else if wishStr == lastWish {
@@ -119,13 +119,13 @@ func Notok(s *discordgo.Session, i *discordgo.InteractionCreate, cmd int64, text
 // DoGoNow gets the AI to draw a chicken in a hurry
 func DoGoNow(s *discordgo.Session, channelID string) {
 	var str = gonow(boost.GetContractDescription(channelID))
-	s.ChannelTyping(channelID)
+	_ = s.ChannelTyping(channelID)
 	wishURL, _ := wishImage(str, "")
 	sendImageReply(s, channelID, wishURL, "", false)
 }
 
 func sendImageReply(s *discordgo.Session, channelID string, wishURL string, wishStr string, hidden bool) {
-	s.ChannelTyping(channelID)
+	_ = s.ChannelTyping(channelID)
 	response, _ := http.Get(wishURL)
 	var data discordgo.MessageSend
 	if wishStr != lastWish {
@@ -142,10 +142,10 @@ func sendImageReply(s *discordgo.Session, channelID string, wishURL string, wish
 		myFile.Name = "ttbb-dalle3.png"
 		myFile.Reader = response.Body
 		data.Files = append(data.Files, &myFile)
-		s.ChannelMessageSendComplex(channelID, &data)
+		_, _ = s.ChannelMessageSendComplex(channelID, &data)
 	} else {
 		// Error message
-		s.ChannelMessageSend(channelID, "Sorry the AIrtists responsed with \""+wishURL+"\"") //"Sorry, the AIrtists are not available at the moment. Some image prompts ")
+		_, _ = s.ChannelMessageSend(channelID, "Sorry the AIrtists responsed with \""+wishURL+"\"") //"Sorry, the AIrtists are not available at the moment. Some image prompts ")
 	}
 }
 
@@ -350,7 +350,10 @@ func downloadFile(filepath string, url string, prompt string) error {
 	id := xid.New()
 	newfile := fmt.Sprintf("%s/%s.png", filepath, id.String())
 	newfilePrompt := fmt.Sprintf("%s/%s.txt", filepath, id.String())
-	os.WriteFile(newfilePrompt, []byte(prompt), 0664)
+	err = os.WriteFile(newfilePrompt, []byte(prompt), 0664)
+	if err != nil {
+		log.Print(err)
+	}
 
 	// Create the file
 	out, err := os.Create(newfile)

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -144,7 +144,10 @@ func isNewEggIncDataAvailable(url string, finalname string) bool {
 			}
 			defer file.Close()
 			// Read the last 1024 bytes from the file
-			file.Seek(-EvalWidth, io.SeekEnd)
+			_, err = file.Seek(-EvalWidth, io.SeekEnd)
+			if err != nil {
+				log.Print(err)
+			}
 			fileBytes := make([]byte, EvalWidth)
 			_, err = file.Read(fileBytes)
 			if err != nil {
@@ -281,10 +284,16 @@ func ExecuteCronJob(s *discordgo.Session) {
 	}
 
 	for _, t := range checkTimes {
-		gocron.Every(1).Day().At(t).Do(crondownloadEggIncData)
+		err := gocron.Every(1).Day().At(t).Do(crondownloadEggIncData)
+		if err != nil {
+			log.Print(err)
+		}
 	}
 
-	gocron.Every(8).Hours().Do(boost.ArchiveContracts, s)
+	err := gocron.Every(8).Hours().Do(boost.ArchiveContracts, s)
+	if err != nil {
+		log.Print(err)
+	}
 
 	<-gocron.Start()
 	log.Print("Exiting cron job")


### PR DESCRIPTION
Ignore error return values in functions ChannelMessageSend and MessageReactionAdd
to prevent build errors.