### PR TITLE
feat: Add slash command to change speedrun sink assignments

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ const slashChange string = "change"
 const slashChangeOneBooster string = "change-one-booster"
 const slashChangePingRole string = "change-ping-role"
 const slashChangePlannedStartCommand string = "change-planned-start"
+const slashChangeSpeedRunSink string = "change-speedrun-sink"
 const slashUnboost string = "unboost"
 const slashPrune string = "prune"
 const slashJoin string = "join-contract"
@@ -287,6 +288,7 @@ var (
 				},
 			},
 		},
+		boost.GetSlashChangeSpeedRunSinkCommand(slashChangeSpeedRunSink),
 		{
 			Name:        slashJoin,
 			Description: "Add farmer or guest to contract.",

--- a/main.go
+++ b/main.go
@@ -507,6 +507,9 @@ var (
 		slashSpeedrun: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleSpeedrunCommand(s, i)
 		},
+		slashChangeSpeedRunSink: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleChangeSpeedrunSinkCommand(s, i)
+		},
 		slashVolunteerSink: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleSlashVolunteerSinkCommand(s, i)
 		},

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -98,8 +98,9 @@ const (
 	SpeedrunStyleWonky   = 0
 	SpeedrunStyleFastrun = 1
 
-	SinkBoostFirst = 0 // First position
-	SinkBoostLast  = 1 // Last position
+	SinkBoostUnset = -1 // Unset position
+	SinkBoostFirst = 0  // First position
+	SinkBoostLast  = 1  // Last position
 )
 
 var boostIconName = "🚀"     // For Reaction tests

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -20,8 +20,8 @@ func GetSlashChangeSpeedRunSinkCommand(cmd string) *discordgo.ApplicationCommand
 			{
 				Type:        discordgo.ApplicationCommandOptionUser,
 				Name:        "sink-crt",
-				Description: "The user to sink during CRT. Used for other sink parameters if those are missing.",
-				Required:    true,
+				Description: "The user to sink during CRT.",
+				Required:    false,
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
@@ -64,8 +64,6 @@ func HandleChangeSpeedrunSinkCommand(s *discordgo.Session, i *discordgo.Interact
 	if opt, ok := optionMap["sink-crt"]; ok {
 		sinkCrt = opt.UserValue(s).Mention()
 		sinkCrt = sinkCrt[2 : len(sinkCrt)-1]
-		sinkBoost = sinkCrt
-		sinkPost = sinkCrt
 	}
 	if opt, ok := optionMap["sink-boosting"]; ok {
 		sinkPost = strings.TrimSpace(opt.StringValue())
@@ -246,12 +244,20 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 	}
 
 	if changeSinksOnly && contract.Speedrun {
-
-		contract.SRData.CrtSinkUserID = sinkCrt
-		contract.SRData.BoostingSinkUserID = sinkBoosting
-		contract.SRData.PostSinkUserID = sinkPost
-
-		return "Updated the speedrun sinks", nil
+		var builder strings.Builder
+		if sinkCrt != "" {
+			contract.SRData.CrtSinkUserID = sinkCrt
+			fmt.Fprintf(&builder, "CRT Sink set to %s\n", contract.Boosters[contract.SRData.CrtSinkUserID].Mention)
+		}
+		if sinkBoosting != "" {
+			contract.SRData.BoostingSinkUserID = sinkBoosting
+			fmt.Fprintf(&builder, "Boosting Sink set to %s\n", contract.Boosters[contract.SRData.BoostingSinkUserID].Mention)
+		}
+		if sinkPost != "" {
+			contract.SRData.PostSinkUserID = sinkPost
+			fmt.Fprintf(&builder, "Post Sink set to %s\n", contract.Boosters[contract.SRData.PostSinkUserID].Mention)
+		}
+		return builder.String(), nil
 	}
 
 	contract.Speedrun = true

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -230,7 +230,7 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 		return "", errors.New("post contract sink not in the contract")
 	}
 
-	if speedrunStyle == SpeedrunStyleWonky {
+	if speedrunStyle == SpeedrunStyleWonky && !changeSinksOnly {
 		// Verify that the sink is a snowflake id
 		if _, err := s.User(sinkBoosting); err != nil {
 			return "", errors.New("boosting sink must be a user mention for Wonky style boost lists")


### PR DESCRIPTION
Added a slash command to change speedrun sink assignments of a running contract.
Included options for different sink scenarios like CRT, boosting, and post-contract.