### PR TITLE
feat: Update contract style based on legs in speedrun

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -48,13 +48,16 @@ const errorSpeedrunContract = "not available for a speedrun contract"
 
 // Create a slice with the names of the ContractState const names
 var contractStateNames = []string{
+	"ContractStateNone",
 	"ContractStateSignup",
 	"ContractStateStarted",
+	"ContractStateCRT",
+	"ContractStateBoosting",
+	"ContractStateBanker",
 	"ContractStateWaiting",
 	"ContractStateCompleted",
 	"ContractStateArchive",
 }
-
 var speedrunStateNames = []string{
 	"SpeedrunStateNone",
 	"SpeedrunStateSignup",
@@ -72,11 +75,15 @@ const (
 	ContractOrderFair      = 3 // Fair based on position percentile of each farmers last 5 contracts. Those with no history use 50th percentile
 	ContractOrderTimeBased = 4 // Time based order
 
-	ContractStateSignup    = 0 // Contract is in signup phase
-	ContractStateStarted   = 1 // Contract is started
-	ContractStateWaiting   = 2 // Waiting for other(s) to join
-	ContractStateCompleted = 3 // Contract is completed
-	ContractStateArchive   = 4 // Contract is ready to archive
+	ContractStateNone      = 0
+	ContractStateSignup    = 1 // Contract is in signup phase
+	ContractStateCRT       = 2
+	ContractStateStarted   = 3 // Contract is started
+	ContractStateBoosting  = 3 // Contract is started
+	ContractStateBanker    = 4
+	ContractStateWaiting   = 5 // Waiting for other(s) to join
+	ContractStateCompleted = 6 // Contract is completed
+	ContractStateArchive   = 7 // Contract is ready to archive
 
 	BoostStateUnboosted = 0 // Unboosted
 	BoostStateTokenTime = 1 // TokenTime or turn to receive tokens
@@ -101,6 +108,16 @@ const (
 	SinkBoostUnset = -1 // Unset position
 	SinkBoostFirst = 0  // First position
 	SinkBoostLast  = 1  // Last position
+
+	ContractFlagFastrun  = 0x00
+	ContractFlagCrt      = 0x01
+	ContractFlagSelfRuns = 0x02
+	ContractFlagBanker   = 0x04
+
+	ContractStyleFastrun           = ContractFlagFastrun
+	ContractStyleFastrunBanker     = ContractFlagBanker
+	ContractStyleSpeedrunBoostList = ContractFlagCrt | ContractFlagFastrun
+	ContractStyleSpeedrunBanker    = ContractFlagCrt | ContractFlagBanker
 )
 
 var boostIconName = "🚀"     // For Reaction tests
@@ -201,6 +218,7 @@ type Contract struct {
 	CRMessageIDs []string // Array of message IDs for chicken run messages
 
 	CoopSize         int
+	Style            int64 // Mask for the Contract Style
 	LengthInSeconds  int
 	BoostOrder       int // How the contract is sorted
 	BoostVoting      int
@@ -437,6 +455,8 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 		contract.Location = append(contract.Location, loc)
 		contract.ContractHash = ContractHash
 		contract.UseInteractionButtons = config.GetTestMode() // Featuer under test
+
+		contract.Style = ContractStyleFastrun
 
 		//GlobalContracts[ContractHash] = append(GlobalContracts[ContractHash], loc)
 		contract.Boosters = make(map[string]*Booster)

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -270,6 +270,16 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 	contract.SRData.SpeedrunState = SpeedrunStateSignup
 	contract.BoostOrder = ContractOrderFair
 
+	if speedrunStyle == SpeedrunStyleWonky {
+		contract.Style = ContractFlagBanker
+	}
+	if selfRuns {
+		contract.Style |= ContractFlagSelfRuns
+	} else {
+		contract.Style &= ^ContractFlagSelfRuns
+
+	}
+
 	// Chicken Runs Calc
 	// Info from https://egg-inc.fandom.com/wiki/Contracts
 	if chickenRuns != 0 {
@@ -306,6 +316,12 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 			break // No more runs to do, skips the Legs++ below
 		}
 		contract.SRData.Legs++
+	}
+
+	if contract.SRData.Legs == 0 {
+		contract.Style &= ^ContractFlagSelfRuns
+	} else {
+		contract.Style |= ContractFlagSelfRuns
 	}
 
 	contract.SRData.StatusStr = getSpeedrunStatusStr(contract)


### PR DESCRIPTION
If the number of legs in a speedrun contract is 0, remove the Self Runs
style flag. Otherwise, add the Self Runs style flag.
Flag isn't used yet but adding it for future use