### PR TITLE
✨ Add thread option in contract settings

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func getSignupContractSettings(channelID string, id string) (string, []discordgo.MessageComponent) {
+func getSignupContractSettings(channelID string, id string, thread bool) (string, []discordgo.MessageComponent) {
 	minValues := 1
 
 	// is this channelID a thread
@@ -17,7 +17,11 @@ func getSignupContractSettings(channelID string, id string) (string, []discordgo
 	builder.WriteString("Use the Contract button if you have to recycle it.\n")
 	builder.WriteString("**Use the menus to set your contract style. These will work until the contract is started.**\n")
 	builder.WriteString("If this contract isn't an immediate start use `/change-planned-start` to add the time to the sign-up message.\n")
-	builder.WriteString("React with 🌊 on the boost list to automaticaly update the thread name.")
+	if thread {
+		builder.WriteString("React with 🌊 on the boost list to automaticaly update the thread name (`/rename-thread`).")
+	} else {
+		builder.WriteString("This contract is in a channel and it cannot be renamed. Create it in a thread to permit renaming.")
+	}
 
 	return builder.String(), []discordgo.MessageComponent{
 		discordgo.ActionsRow{

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -221,7 +221,7 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	}
 
 	if len(contract.Location) == 1 {
-		str, comp := getSignupContractSettings(contract.Location[0].ChannelID, contract.ContractHash)
+		str, comp := getSignupContractSettings(contract.Location[0].ChannelID, contract.ContractHash, makeThread)
 
 		if ChannelID != i.ChannelID {
 			str += "\nThis message can be moved into the contract thread via `/contract-settings` command in that thread."
@@ -507,7 +507,12 @@ func HandleContractSettingsCommand(s *discordgo.Session, i *discordgo.Interactio
 	})
 	contract := FindContract(i.ChannelID)
 	if contract != nil {
-		str, comp := getSignupContractSettings(contract.Location[0].ChannelID, contract.ContractHash)
+		inThread := false
+		ch, err := s.Channel(i.ChannelID)
+		if err == nil && ch.IsThread() {
+			inThread = true
+		}
+		str, comp := getSignupContractSettings(contract.Location[0].ChannelID, contract.ContractHash, inThread)
 		_, _ = s.FollowupMessageCreate(i.Interaction, true,
 			&discordgo.WebhookParams{
 				Content:    str,


### PR DESCRIPTION
Allow users to differentiate between contracts in a channel and contracts in a thread.