### PR TITLE
feat(boost): Update Boost order description

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -141,7 +141,7 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 						},
 						{
 							Label:       "ELR Order",
-							Description: "Boost order is based on ELR",
+							Description: "Highest ELR first",
 							Value:       "elr",
 							Emoji: &discordgo.ComponentEmoji{
 								Name: "🧮",


### PR DESCRIPTION
Changed "Boost order is based on ELR" to "Highest ELR first" in description.