### PR TITLE
refactor: Update contract creator IDs and limit displayed user names to 12 characters

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -344,6 +344,7 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, coop
 	contract.OrderRevision = 0
 	changeContractState(contract, ContractStateSignup)
 	contract.CreatorID = append(contract.CreatorID, userID)               // starting userid
+	contract.CreatorID = append(contract.CreatorID, "662685289885466672") // DipDip
 	contract.CreatorID = append(contract.CreatorID, "650743870253957160") // Mugwump
 	contract.Speedrun = false
 	contract.Banker.SinkBoostPosition = SinkBoostFirst


### PR DESCRIPTION
feat: Add initial response message for contract calculation request

refactor: Limit displayed user names to 12 characters in booster calculation data

fix: Use FollowupMessageCreate instead of InteractionRespond for follow-up message