### PR TITLE
fix: Switched handle method for Stones auto-complete from Contract to Stones.

### DIFF
--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ var (
 			boost.HandleStonesAutoComplete(s, i)
 		},
 		slashTeamworkEval: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			boost.HandleContractAutoComplete(s, i)
+			boost.HandleStonesAutoComplete(s, i)
 		},
 		slashTokenEditTrack: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			data := i.ApplicationCommandData()


### PR DESCRIPTION
## Description
This pull request addresses the issue where the handle method for Stones auto-complete was incorrectly using Contract instead of Stones. The fix ensures that the correct handling method is now being utilized, resolving the issue at hand.

### Changes Made
- Switched handle method for Stones auto-complete from Contract to Stones

### Commits
- fix: Switched handle method for Stones auto-complete from Contract to Stones.