### PR TITLE
refactor: remove unused token tracking variables

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -87,12 +87,6 @@ func resetTokenTracking(tv *tokenValue) {
 	tv.LinkRecieved = true
 	tv.Sent = nil
 	tv.Received = nil
-	//tv.TokenSentTime = nil
-	//tv.TokenReceivedTime = nil
-	//tv.TokenReceivedUserID = nil
-	//tv.TokenSentUserID = nil
-	//tv.TokenSentValues = nil
-	//tv.TokenReceivedValues = nil
 	tv.SumValueSent = 0.0
 	tv.SumValueReceived = 0.0
 	tv.TokenDelta = 0.0


### PR DESCRIPTION
Eliminate commented-out variables in the resetTokenTracking function. This 
cleans up the code and improves readability by removing unnecessary 
clutter, focusing on the essential components of the function.