### PR TITLE
fix: correct variable name from finalname to filename

### DIFF
--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -92,16 +92,16 @@ func HandleReloadContractsCommand(s *discordgo.Session, i *discordgo.Interaction
 
 }
 
-func isNewEggIncDataAvailable(url string, finalname string) bool {
-	if _, err := os.Stat(finalname); err == nil {
+func isNewEggIncDataAvailable(url string, filename string) bool {
+	if _, err := os.Stat(filename); err == nil {
 		// Get the current file size
-		fileInfo, err := os.Stat(finalname)
+		fileInfo, err := os.Stat(filename)
 		if err != nil {
 			log.Print(err)
 			return true
 		}
 
-		switch finalname {
+		switch filename {
 		case eggIncContractsFile:
 			if time.Since(lastContractUpdate) < 2*time.Hour {
 				return false
@@ -126,7 +126,7 @@ func isNewEggIncDataAvailable(url string, finalname string) bool {
 		req.Header.Add("Range", rangeHeader)
 		req.Header.Add("Cache-Control", "no-cache, no-store, must-revalidate")
 		req.Header.Add("Pragma", "no-cache")
-		req.Header.Add("Expires", "0")
+		req.Header.Add("Expires", time.Now().Add(-26*time.Hour).Format(time.RFC1123))
 		req.Header.Add("Clear-Site-Data", "*")
 		//		log.Print("EI-Contracts: Requested Range", rangeHeader)
 		var client http.Client
@@ -147,7 +147,7 @@ func isNewEggIncDataAvailable(url string, finalname string) bool {
 
 		if len(body) > 0 {
 			// Test if the end of the the file eggIncContractsFile is the same as the body
-			file, err := os.Open(finalname)
+			file, err := os.Open(filename)
 			if err != nil {
 				log.Print(err)
 				return false
@@ -169,7 +169,7 @@ func isNewEggIncDataAvailable(url string, finalname string) bool {
 
 			// Compare the last 1024 bytes of the file with the body
 			if string(fileBytes) == string(body) && len(fileBytes) == len(body) {
-				switch finalname {
+				switch filename {
 				case eggIncContractsFile:
 					if lastContractUpdate.IsZero() {
 						lastContractUpdate = time.Now()


### PR DESCRIPTION
Update the function signature and all references to the 
`finalname` variable to `filename` for consistency. This 
change improves code readability and maintains uniformity 
across the function. Additionally, adjust the `Expires` 
header to set a more appropriate value based on the 
current time.