### PR TITLE
feat: add support for 6 and 8 token boosts

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -43,6 +43,14 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) string {
 
 	if len(contract.Boosters) != contract.CoopSize || contract.State == ContractStateSignup {
 		outputStr += fmt.Sprintf("### Boost ordering is %s\n", getBoostOrderString(contract))
+
+		if contract.Style&ContractFlag6Tokens != 0 {
+			outputStr += fmt.Sprintf(">  6️⃣%s boosting for everyone!\n", contract.TokenStr)
+		} else if contract.Style&ContractFlag8Tokens != 0 {
+			outputStr += fmt.Sprintf(">  8️⃣%s boosting for everyone!\n", contract.TokenStr)
+		} else if contract.Style&ContractFlagDynamicTokens != 0 {
+			outputStr += fmt.Sprintf("> 🤖 Dynamic tokens (coming soon)\n")
+		}
 	}
 
 	outputStr += fmt.Sprintf("> Coordinator: <@%s>\n", contract.CreatorID[0])

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -161,6 +161,24 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 					MaxValues:   1,
 					Options: []discordgo.SelectMenuOption{
 						{
+							Label:       "6 token boosts",
+							Description: "Everyone joins with 6 token boosts",
+							Value:       "boost6",
+							Default:     (contract.Style & ContractFlag6Tokens) != 0,
+							Emoji: &discordgo.ComponentEmoji{
+								Name: "6️⃣",
+							},
+						},
+						{
+							Label:       "8 token boosts",
+							Description: "Everyone joins with 8 token boosts",
+							Value:       "boost8",
+							Default:     (contract.Style & ContractFlag8Tokens) != 0,
+							Emoji: &discordgo.ComponentEmoji{
+								Name: "8️⃣",
+							},
+						},
+						{
 							Label:       "Dynamic Boost Tokens",
 							Description: "Based on highest 120min delivery rate",
 							Value:       "dynamic",

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -421,9 +421,29 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		values := data.Values
 		if len(values) == 0 {
 			contract.Style &= ^ContractFlagDynamicTokens
+			contract.Style &= ^ContractFlag6Tokens
+			contract.Style &= ^ContractFlag8Tokens
 		} else {
 			switch values[0] {
+			case "boost6":
+				contract.Style &= ^ContractFlagDynamicTokens
+				contract.Style &= ^ContractFlag8Tokens
+				if contract.Style&ContractFlag6Tokens != 0 {
+					contract.Style &= ^ContractFlag6Tokens
+				} else {
+					contract.Style |= ContractFlag6Tokens
+				}
+			case "boost8":
+				contract.Style &= ^ContractFlagDynamicTokens
+				contract.Style &= ^ContractFlag6Tokens
+				if contract.Style&ContractFlag8Tokens != 0 {
+					contract.Style &= ^ContractFlag8Tokens
+				} else {
+					contract.Style |= ContractFlag8Tokens
+				}
 			case "dynamic":
+				contract.Style &= ^ContractFlag6Tokens
+				contract.Style &= ^ContractFlag8Tokens
 				if contract.Style&ContractFlagDynamicTokens != 0 {
 					contract.Style &= ^ContractFlagDynamicTokens
 				} else {


### PR DESCRIPTION
Introduce new token boost options for contracts, allowing users to select 
between 6 and 8 token boosts. Update the contract style flags to include 
`ContractFlag6Tokens` and `ContractFlag8Tokens`. Modify the contract 
handling logic to set the desired tokens based on user selection, and 
update the output display to reflect the selected boost type. This 
enhances user experience by providing more flexibility in boost options.