### PR TITLE
feat(boost): conditionally set tokens based on contract style

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -463,7 +463,10 @@ func AddBoostTokens(s *discordgo.Session, i *discordgo.InteractionCreate, setCou
 		b.TokensWanted = 0
 	}
 
-	farmerstate.SetTokens(b.UserID, b.TokensWanted)
+	if (ContractFlagDynamicTokens+ContractFlag8Tokens+ContractFlag6Tokens)&contract.Style == 0 {
+		// Only set this if the contract isn't controlling the wanted tokens
+		farmerstate.SetTokens(b.UserID, b.TokensWanted)
+	}
 
 	refreshBoostListMessage(s, contract)
 

--- a/src/boost/boost_reactions.go
+++ b/src/boost/boost_reactions.go
@@ -50,7 +50,9 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 			var b = contract.Boosters[r.UserID]
 			if b != nil {
 				var tokenCount = slices.Index(numberSlice, emojiName)
-				farmerstate.SetTokens(r.UserID, tokenCount)
+				if (ContractFlagDynamicTokens+ContractFlag8Tokens+ContractFlag6Tokens)&contract.Style == 0 {
+					farmerstate.SetTokens(r.UserID, tokenCount)
+				}
 				b.TokensWanted = tokenCount
 				redraw = true
 			}


### PR DESCRIPTION
Add checks to ensure tokens are only set when the contract does not 
control the wanted tokens. This prevents unintended token adjustments 
when specific contract styles are active, improving the integrity of 
token management in the system.