### PR TITLE
feat: add Lithium artifact and update related components

### DIFF
--- a/src/boost/artifacts.go
+++ b/src/boost/artifacts.go
@@ -369,6 +369,7 @@ func getArtifactsComponents(userID string, channelID string, contractOnly bool) 
 		_, firework := ei.FindEggComponentEmoji("FIREWORK")
 		_, pumpkin := ei.FindEggComponentEmoji("PUMPKIN")
 		_, waterballoon := ei.FindEggComponentEmoji("WATERBALLOON")
+		_, lithium := ei.FindEggComponentEmoji("LITHIUM")
 
 		component = append(component, discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
@@ -376,7 +377,7 @@ func getArtifactsComponents(userID string, channelID string, contractOnly bool) 
 					CustomID:    "as_#COLLEGG#" + userID + "#" + temp,
 					Placeholder: "Select your Colleggtibles",
 					MinValues:   &minV,
-					MaxValues:   6,
+					MaxValues:   7,
 					Options: []discordgo.SelectMenuOption{
 						{
 							Label:       "Carbon Fiber",
@@ -416,6 +417,16 @@ func getArtifactsComponents(userID string, channelID string, contractOnly bool) 
 							Emoji: &discordgo.ComponentEmoji{
 								Name: firework.Name,
 								ID:   firework.ID,
+							},
+						},
+						{
+							Label:       "Lithium",
+							Description: "10% Vehicle Cost",
+							Value:       "Lithium",
+							Default:     strings.Contains(coll, "Pumpkin"),
+							Emoji: &discordgo.ComponentEmoji{
+								Name: lithium.Name,
+								ID:   lithium.ID,
 							},
 						},
 						{

--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -97,6 +97,7 @@ var EggEmojiMap = map[string]EggEmojiData{
 	"CHOCOLATE":      {"egg_chocolate", "1279200983523524659", "1280382217822146560"},
 	"EASTER":         {"egg_easter", "1279201048845881414", "1280382259630964767"},
 	"CARBON-FIBER":   {"egg_carbonfiber", "1279202173904752802", "1280385218213187640"},
+	"LITHIUM":        {"egg_lithium", "1305429259048718387", "1305429887749853185"},
 	"SOUL":           {"egg_soul", "1279201265628348490", "1280382995282526208"},
 	"PROPHECY":       {"egg_prophecy", "1279201195872878652", "1280382926470643754"},
 }
@@ -275,6 +276,7 @@ var ArtifactMap = map[string]*Artifact{
 	"Chocolate":    {Type: "Collegg", Quality: "3x", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 	"Easter":       {Type: "Collegg", Quality: "5%", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 	"Firework":     {Type: "Collegg", Quality: "5%", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
+	"Lithium":      {Type: "Collegg", Quality: "10%", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 	"Pumpkin":      {Type: "Collegg", Quality: "5%", ShipBuff: 1.05, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 	"Waterballoon": {Type: "Collegg", Quality: "95%", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 }


### PR DESCRIPTION
Add Lithium artifact with 10% vehicle cost to the ArtifactMap. 
Increase the maximum selectable values for colleggtibles from 6 to 7. 
Include Lithium in the artifacts options with its corresponding emoji 
and description. Update the EggEmojiMap to include Lithium's emoji 
data for consistency across the application.