### PR TITLE
fix: update default value for Lithium artifact

### DIFF
--- a/src/boost/artifacts.go
+++ b/src/boost/artifacts.go
@@ -423,7 +423,7 @@ func getArtifactsComponents(userID string, channelID string, contractOnly bool) 
 							Label:       "Lithium",
 							Description: "10% Vehicle Cost",
 							Value:       "Lithium",
-							Default:     strings.Contains(coll, "Pumpkin"),
+							Default:     strings.Contains(coll, "Lithium"),
 							Emoji: &discordgo.ComponentEmoji{
 								Name: lithium.Name,
 								ID:   lithium.ID,


### PR DESCRIPTION
Change the default value for the Lithium artifact in the 
getArtifactsComponents function to correctly reflect its 
association with the "Lithium" string instead of "Pumpkin". 
This ensures accurate behavior in the application logic.