### PR TITLE
fix: correct Lithium description in artifacts

### DIFF
--- a/src/boost/artifacts.go
+++ b/src/boost/artifacts.go
@@ -421,7 +421,7 @@ func getArtifactsComponents(userID string, channelID string, contractOnly bool) 
 						},
 						{
 							Label:       "Lithium",
-							Description: "10% Vehicle Cost",
+							Description: "-10% Vehicle Cost",
 							Value:       "Lithium",
 							Default:     strings.Contains(coll, "Lithium"),
 							Emoji: &discordgo.ComponentEmoji{


### PR DESCRIPTION
Update description for the Lithium component to a 
consistent format by changing "10% Vehicle Cost" to 
"-10% Vehicle Cost". This improves clarity and aligns with 
the formatting of other components.