### PR TITLE
fix: update deflector abbreviation format in stones.go

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -504,7 +504,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 				as.note = append(as.note, "Missing Deflector")
 			} else {
 				as.note = append(as.note, fmt.Sprintf("DEFL from BuffHist %2.0f%%", bestDeflectorPercent))
-				as.deflector.abbrev = "B-H"
+				as.deflector.abbrev = fmt.Sprintf("%d%%", int(bestDeflectorPercent))
 				as.deflector.percent = bestDeflectorPercent
 				everyoneDeflectorPercent += as.deflector.percent
 			}


### PR DESCRIPTION
Change the deflector abbreviation from a static value to a dynamic 
percentage format. This improves clarity by providing the actual 
deflector percentage instead of a generic label, enhancing the 
information conveyed in the notes.