### PR TITLE
feat: update banker state when setting boosting sink

### DIFF
--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -412,6 +412,9 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 		}
 		if sinkBoosting != "" {
 			contract.Banker.BoostingSinkUserID = sinkBoosting
+			if contract.State == ContractStateBanker {
+				contract.Banker.CurrentBanker = contract.Banker.BoostingSinkUserID
+			}
 			fmt.Fprintf(&builder, "Boosting Sink set to %s\n", contract.Boosters[contract.Banker.BoostingSinkUserID].Mention)
 		}
 		if sinkPost != "" {


### PR DESCRIPTION
Set the current banker to the boosting sink user ID when the contract 
state set to Banker. This change ensures that the correct banker 
is maintained during the boosting process, improving the accuracy 
of the contract's state management.