### PR TITLE
feat(bottools): add token value calculation utilities

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/track"
@@ -183,7 +184,7 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial})
 			contract.mutex.Unlock()
 			if contract.BoostOrder == ContractOrderTVal {
-				tval := getTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+				tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
 				contract.mutex.Lock()
 				contract.Boosters[fromUserID].TokenValue += tval * float64(count)
 				contract.Boosters[b.UserID].TokenValue -= tval * float64(count)

--- a/src/boost/boost_calctval.go
+++ b/src/boost/boost_calctval.go
@@ -2,7 +2,6 @@ package boost
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"time"
@@ -191,7 +190,7 @@ func calculateTokenValueFromLog(contract *Contract, duration time.Duration, deta
 		if tokens.FromUserID == userID && tokens.ToUserID == userID {
 			TokensFarmed = append(TokensFarmed, tokens)
 		} else if tokens.FromUserID == userID {
-			tokens.Value = getTokenValue(tokens.Time.Sub(contract.StartTime).Seconds(), duration.Seconds())
+			tokens.Value = bottools.GetTokenValue(tokens.Time.Sub(contract.StartTime).Seconds(), duration.Seconds())
 			tokens.Value *= float64(tokens.Quantity)
 			TokensSent = append(TokensSent, tokens)
 			SentValue += tokens.Value
@@ -199,7 +198,7 @@ func calculateTokenValueFromLog(contract *Contract, duration time.Duration, deta
 			tokenCountTo[tokens.ToNick] += tokens.Quantity
 			tokenValueTo[tokens.ToNick] += tokens.Value
 		} else if tokens.ToUserID == userID {
-			tokens.Value = getTokenValue(tokens.Time.Sub(contract.StartTime).Seconds(), duration.Seconds())
+			tokens.Value = bottools.GetTokenValue(tokens.Time.Sub(contract.StartTime).Seconds(), duration.Seconds())
 			tokens.Value *= float64(tokens.Quantity)
 			TokensReceived = append(TokensReceived, tokens)
 			ReceivedValue += tokens.Value
@@ -222,17 +221,17 @@ func calculateTokenValueFromLog(contract *Contract, duration time.Duration, deta
 
 	field = append(field, &discordgo.MessageEmbedField{
 		Name:   fmt.Sprintf("Value <t:%d:R>", time.Now().Unix()),
-		Value:  fmt.Sprintf("%1.3f\n", getTokenValue(offsetTime, duration.Seconds())),
+		Value:  fmt.Sprintf("%1.3f\n", bottools.GetTokenValue(offsetTime, duration.Seconds())),
 		Inline: true,
 	})
 	field = append(field, &discordgo.MessageEmbedField{
 		Name:   fmt.Sprintf("<t:%d:R>", time.Now().Add(30*time.Minute).Unix()),
-		Value:  fmt.Sprintf("%1.3f\n", getTokenValue(offsetTime+(30*60), duration.Seconds())),
+		Value:  fmt.Sprintf("%1.3f\n", bottools.GetTokenValue(offsetTime+(30*60), duration.Seconds())),
 		Inline: true,
 	})
 	field = append(field, &discordgo.MessageEmbedField{
 		Name:   fmt.Sprintf("<t:%d:R>", time.Now().Add(60*time.Minute).Unix()),
-		Value:  fmt.Sprintf("%1.3f\n", getTokenValue(offsetTime+(60*60), duration.Seconds())),
+		Value:  fmt.Sprintf("%1.3f\n", bottools.GetTokenValue(offsetTime+(60*60), duration.Seconds())),
 		Inline: true,
 	})
 
@@ -424,10 +423,4 @@ func calculateTokenValueFromLog(contract *Contract, duration time.Duration, deta
 	}
 
 	return embed
-}
-
-func getTokenValue(seconds float64, durationSeconds float64) float64 {
-	currentval := max(0.03, math.Pow(1-0.9*(min(seconds, durationSeconds)/durationSeconds), 4))
-
-	return math.Round(currentval*1000) / 1000
 }

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 )
@@ -106,7 +107,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) string {
 				contract.EstimatedDuration = c.EstimatedDuration
 			}
 		}
-		tval := getTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+		tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
 		outputStr += fmt.Sprintf("> Current TVal: %2.3g\n", tval)
 	}
 

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/track"
@@ -390,7 +391,7 @@ func HandleTokenIDAutoComplete(s *discordgo.Session, i *discordgo.InteractionCre
 	var myTokes []ei.TokenUnitLog
 	for _, t := range c.TokenLog {
 		if t.FromUserID == i.Member.User.ID && t.ToUserID != i.Member.User.ID {
-			t.Value = getTokenValue(t.Time.Sub(c.StartTime).Seconds(), c.EstimatedDuration.Seconds()) * float64(t.Quantity)
+			t.Value = bottools.GetTokenValue(t.Time.Sub(c.StartTime).Seconds(), c.EstimatedDuration.Seconds()) * float64(t.Quantity)
 			myTokes = append(myTokes, t)
 		}
 	}
@@ -536,7 +537,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 			xid, _ := xid.FromString(t.Serial)
 			if xid.Counter() == tokenIndex {
 				c.TokenLog[i].Quantity = int(tokenCount)
-				c.TokenLog[i].Value = getTokenValue(c.TokenLog[i].Time.Sub(c.StartTime).Seconds(), c.EstimatedDuration.Seconds()) * float64(c.TokenLog[i].Quantity)
+				c.TokenLog[i].Value = bottools.GetTokenValue(c.TokenLog[i].Time.Sub(c.StartTime).Seconds(), c.EstimatedDuration.Seconds()) * float64(c.TokenLog[i].Quantity)
 				modifiedTokenLog = c.TokenLog[i]
 				str = "Token count modified"
 				break

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/track"
 	"github.com/rs/xid"
@@ -61,7 +62,7 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: tokensToSend, FromUserID: cUserID, FromNick: contract.Boosters[cUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial})
 			contract.mutex.Unlock()
 			if contract.BoostOrder == ContractOrderTVal {
-				tval := getTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+				tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
 				contract.Boosters[cUserID].TokenValue += tval * float64(tokensToSend)
 				contract.Boosters[b.UserID].TokenValue -= tval * float64(tokensToSend)
 				// Don't reorder on the bag send as we need a tiny amount of stability for the send to get to the correct person

--- a/src/bottools/tokens.go
+++ b/src/bottools/tokens.go
@@ -1,0 +1,91 @@
+package bottools
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+// GetTokenValue calculates the token value based on the given parameters
+func GetTokenValue(seconds float64, durationSeconds float64) float64 {
+	currentval := max(0.03, math.Pow(1-0.9*(min(seconds, durationSeconds)/durationSeconds), 4))
+
+	return math.Round(currentval*1000) / 1000
+}
+
+// CalculateFutureTokenLogs calculates the future token logs based on the given parameters
+func CalculateFutureTokenLogs(maxEntries int, startTime time.Time, minutesPerToken int, duration time.Duration, rateSecondPerTokens float64) ([]float64, []time.Time, []float64, []time.Time) {
+	estimatedCapacity := int(maxEntries * 2)
+
+	futureTokenLog := make([]float64, 0, estimatedCapacity)
+	futureTokenLogGG := make([]float64, 0, estimatedCapacity)
+	futureTokenLogTimes := make([]time.Time, 0, estimatedCapacity)
+	futureTokenLogGGTimes := make([]time.Time, 0, estimatedCapacity)
+
+	endTime := startTime.Add(duration)
+	tokenTime := time.Now()
+	for tokenTime.Before(endTime) {
+		val := GetTokenValue(tokenTime.Sub(startTime).Seconds(), duration.Seconds())
+		futureTokenLog = append(futureTokenLog, val)
+		futureTokenLogTimes = append(futureTokenLogTimes, tokenTime)
+		futureTokenLogGG = append(futureTokenLogGG, val)
+		futureTokenLogGGTimes = append(futureTokenLogTimes, tokenTime)
+		tokenTime = tokenTime.Add(time.Duration(rateSecondPerTokens) * time.Second)
+		if len(futureTokenLog) > maxEntries {
+			break
+		}
+	}
+	// Now for the timer tokens, start with next timer
+	tokenTime = startTime.Add(time.Duration(minutesPerToken) * time.Minute)
+	for tokenTime.Before(time.Now()) {
+		tokenTime = tokenTime.Add(time.Duration(minutesPerToken) * time.Minute)
+	}
+	for tokenTime.Before(endTime) {
+		val := GetTokenValue(tokenTime.Sub(startTime).Seconds(), duration.Seconds())
+		futureTokenLog = append(futureTokenLog, val)
+		futureTokenLogTimes = append(futureTokenLogTimes, tokenTime)
+		tokenTime = tokenTime.Add(time.Duration(minutesPerToken) * time.Minute)
+	}
+
+	sort.Slice(futureTokenLog, func(i, j int) bool {
+		return futureTokenLog[i] > futureTokenLog[j]
+	})
+	sort.Slice(futureTokenLogTimes, func(i, j int) bool {
+		return futureTokenLogTimes[i].Before(futureTokenLogTimes[j])
+	})
+	futureTokenLogGG = append(futureTokenLogGG, futureTokenLog...)
+	futureTokenLogGGTimes = append(futureTokenLogGGTimes, futureTokenLogTimes...)
+	sort.Slice(futureTokenLogGG, func(i, j int) bool {
+		return futureTokenLogGG[i] > futureTokenLogGG[j]
+	})
+	sort.Slice(futureTokenLogGGTimes, func(i, j int) bool {
+		return futureTokenLogGGTimes[i].Before(futureTokenLogGGTimes[j])
+	})
+
+	return futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes
+}
+
+// CalculateTcountTtime calculates the token count and time based on the given parameters
+func CalculateTcountTtime(tokenValue float64, tval float64, valueLog []float64, valueTime []time.Time) (string, string, int) {
+	tcount := "√"
+	ttime := ""
+	count := 0
+
+	uTval := tokenValue
+	if uTval < tval {
+		tcount = "∞"
+		for i, v := range valueLog {
+			uTval += v
+			if uTval >= tval {
+				tcount = fmt.Sprintf("%d", i+1)
+				count = i + 1
+				if i < len(valueTime) { // Ensure index is within bounds
+					ttime = fmt.Sprintf("<t:%d:R>", valueTime[i].Unix())
+				}
+				break
+			}
+		}
+	}
+	return tcount, ttime, count
+}


### PR DESCRIPTION
The changes in this commit introduce a new package `bottools` that provides utility functions for calculating token values and future token logs. The main changes are:

1. Added the `GetTokenValue` function to calculate the token value based on the given time and duration parameters.
2. Added the `CalculateFutureTokenLogs` function to calculate the future token logs based on the given parameters, including the start time, duration, and token generation rate.
3. Added the `CalculateTcountTtime` function to calculate the token count and time based on the given token value and value log.

These utilities are used in the `track` and `boost` packages to handle token-related calculations and operations.