### PR TITLE
feat: Improve token tracking dynamic calculation

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -417,36 +417,40 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 			Inline: false,
 		})
 
-		// What is the current tokens per second from start time to now when sent count is td.Sent
-		// and received count is td.Received
-		// This is the current rate of tokens per second
-		rateSecondPerTokensDynamic := float64(time.Since(td.StartTime).Seconds()) / float64(td.SentCount)
+		if td.SentCount >= 3 {
+			// What is the current tokens per second from start time to now when sent count is td.Sent
+			// and received count is td.Received
+			// This is the current rate of tokens per second
+			dynamic := float64(time.Since(td.StartTime).Seconds()) / float64(td.SentCount)
 
-		futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes =
-			bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, td.MinutesPerToken, duration, rateSecondPerTokensDynamic)
-		if ugg > 1.0 || gg > 1.0 {
-			valueLog = futureTokenLogGG
-			valueTime = futureTokenLogGGTimes
-		} else {
-			valueLog = futureTokenLog
-			valueTime = futureTokenLogTimes
-		}
-		tcount, ttime, count = bottools.CalculateTcountTtime(td.TokenDelta, targetTval, valueLog, valueTime)
-
-		// I have an array of floats in valueLog, want to convert the first tcount to a string
-		// separating values with a comma
-		valueLogStr = make([]string, 0, count)
-		for i := 0; i < int(count); i++ {
-			if i < len(valueLog) {
-				valueLogStr = append(valueLogStr, fmt.Sprintf("%4.3f", valueLog[i]))
+			rateSecondPerTokensDynamic := (dynamic + rateSecondPerTokens) / 2.0
+			//((actual tokens/min) + 0.101332 )/2
+			futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes =
+				bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, td.MinutesPerToken, duration, rateSecondPerTokensDynamic)
+			if ugg > 1.0 || gg > 1.0 {
+				valueLog = futureTokenLogGG
+				valueTime = futureTokenLogGGTimes
+			} else {
+				valueLog = futureTokenLog
+				valueTime = futureTokenLogTimes
 			}
-		}
+			tcount, ttime, count = bottools.CalculateTcountTtime(td.TokenDelta, targetTval, valueLog, valueTime)
 
-		field = append(field, &discordgo.MessageEmbedField{
-			Name:   "Future Tokens (Dynamic)",
-			Value:  fmt.Sprintf("Seconds/Token: %d\nRemaining: %s %s\nValues: %s", int(rateSecondPerTokensDynamic), tcount, ttime, strings.Join(valueLogStr, " ,")),
-			Inline: false,
-		})
+			// I have an array of floats in valueLog, want to convert the first tcount to a string
+			// separating values with a comma
+			valueLogStr = make([]string, 0, count)
+			for i := 0; i < int(count); i++ {
+				if i < len(valueLog) {
+					valueLogStr = append(valueLogStr, fmt.Sprintf("%4.3f", valueLog[i]))
+				}
+			}
+
+			field = append(field, &discordgo.MessageEmbedField{
+				Name:   "Future Tokens (Dynamic)",
+				Value:  fmt.Sprintf("Seconds/Token: %d\nRemaining: %s %s\nValues: %s", int(rateSecondPerTokensDynamic), tcount, ttime, strings.Join(valueLogStr, " ,")),
+				Inline: false,
+			})
+		}
 
 		// Show Token Teamwork score vs max.
 		myTeamwork := calculateTokenTeamwork(td.DurationTime.Seconds(), td.MinutesPerToken, td.SumValueSent, td.SumValueReceived)


### PR DESCRIPTION
Calculates the dynamic tokens per second rate based on the current sent count and
time since start. This provides a more accurate estimate of the future token
logs, especially when the token rate is changing over time.