### PR TITLE
feat(track): update duration display logic

### DIFF
--- a/src/track/track.go
+++ b/src/track/track.go
@@ -197,7 +197,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 		duration = td.DurationTime
 		fmt.Fprintf(&description, "Duration (Estimate): **%s** \n", ts[:len(ts)-2])
 	} else {
-		duration = td.TimeFromCoopStatus.Sub(td.StartTime)
+		duration = td.DurationTime
 		fmt.Fprintf(&description, "Duration (<t:%d:R>): **%s**\n", td.TimeFromCoopStatus.Unix(), ts[:len(ts)-2])
 	}
 


### PR DESCRIPTION
The changes update the logic for displaying the duration of a token
tracking event. Previously, the duration was calculated based on the
difference between the start time and the time from the coop status.
This has been changed to use the pre-calculated duration time, which
provides a more accurate and consistent display of the duration.