### PR TITLE
feat: Add contract creation and boosting timestamps

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -232,6 +232,8 @@ type Contract struct {
 	ThreadName                string
 	ThreadRenameTime          time.Time
 	EstimateUpdateTime        time.Time
+	TimeCRT                   time.Time // When the contract was created
+	TimeBoosting              time.Time // When the contract boost started
 
 	CRMessageIDs []string // Array of message IDs for chicken run messages
 
@@ -312,8 +314,12 @@ func changeContractState(contract *Contract, newstate int) {
 	// This will avoid adding this logic in multiple places
 	switch contract.State {
 	case ContractStateCRT:
+		contract.TimeCRT = time.Now()
 		contract.Banker.CurrentBanker = contract.Banker.CrtSinkUserID
 	case ContractStateBanker:
+		if contract.TimeBoosting.IsZero() {
+			contract.TimeBoosting = time.Now()
+		}
 		contract.Banker.CurrentBanker = contract.Banker.BoostingSinkUserID
 	case ContractStateWaiting:
 		if contract.Style&ContractFlagBanker != 0 {

--- a/src/boost/boost_cooptval.go
+++ b/src/boost/boost_cooptval.go
@@ -161,8 +161,13 @@ func calculateTokenValueCoopLog(contract *Contract, duration time.Duration, tval
 	const rateSecondPerTokens = 592      // Rate at which tokens are generated
 	// 1 token = 591.6 seconds / 9.86 minutes
 
+	var crtTime time.Duration
+	if !contract.TimeCRT.IsZero() {
+		crtTime = contract.TimeBoosting.Sub(contract.TimeCRT)
+	}
+
 	futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes :=
-		bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, contract.StartTime, contract.MinutesPerToken, duration, rateSecondPerTokens)
+		bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, contract.StartTime, crtTime, contract.MinutesPerToken, duration, rateSecondPerTokens)
 
 	// Now we have a sorted list of future token logs
 	for _, t := range contract.TokenLog {

--- a/src/bottools/tokens.go
+++ b/src/bottools/tokens.go
@@ -15,7 +15,7 @@ func GetTokenValue(seconds float64, durationSeconds float64) float64 {
 }
 
 // CalculateFutureTokenLogs calculates the future token logs based on the given parameters
-func CalculateFutureTokenLogs(maxEntries int, startTime time.Time, minutesPerToken int, duration time.Duration, rateSecondPerTokens float64) ([]float64, []time.Time, []float64, []time.Time) {
+func CalculateFutureTokenLogs(maxEntries int, startTime time.Time, crtTime time.Duration, minutesPerToken int, duration time.Duration, rateSecondPerTokens float64) ([]float64, []time.Time, []float64, []time.Time) {
 	estimatedCapacity := int(maxEntries * 2)
 
 	futureTokenLog := make([]float64, 0, estimatedCapacity)
@@ -39,6 +39,7 @@ func CalculateFutureTokenLogs(maxEntries int, startTime time.Time, minutesPerTok
 	}
 	// Now for the timer tokens, start with next timer
 	tokenTime = startTime.Add(time.Duration(minutesPerToken) * time.Minute)
+	tokenTime = tokenTime.Add(crtTime) // Add in CRT Offset
 	for tokenTime.Before(time.Now()) {
 		tokenTime = tokenTime.Add(time.Duration(minutesPerToken) * time.Minute)
 	}

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -391,7 +391,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 			const rateSecondPerTokens = 592      // Rate at which tokens are generated
 			// 1 token = 591.6 seconds / 9.86 minutes
 			futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes :=
-				bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, td.MinutesPerToken, duration, rateSecondPerTokens)
+				bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, 0, td.MinutesPerToken, duration, rateSecondPerTokens)
 			gg, ugg := ei.GetGenerousGiftEvent()
 			var valueLog []float64
 			var valueTime []time.Time
@@ -442,7 +442,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 				rateSecondPerTokensDynamic := (dynamic + rateSecondPerTokens) / 2.0
 				//((actual tokens/min) + 0.101332 )/2
 				futureTokenLog, futureTokenLogTimes, futureTokenLogGG, futureTokenLogGGTimes =
-					bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, td.MinutesPerToken, duration, rateSecondPerTokensDynamic)
+					bottools.CalculateFutureTokenLogs(maxFutureTokenLogEntries, td.StartTime, 0, td.MinutesPerToken, duration, rateSecondPerTokensDynamic)
 				if ugg > 1.0 || gg > 1.0 {
 					valueLog = futureTokenLogGG
 					valueTime = futureTokenLogGGTimes


### PR DESCRIPTION
This change adds two new fields to the `Contract` struct: `TimeCRT` and `TimeBoosting`. These fields store the timestamps when the contract was created and when the boosting started, respectively.

The changes also update the `changeContractState` function to set these timestamps when the contract state changes to `ContractStateCRT` and `ContractStateBanker`.

Additionally, the `CalculateFutureTokenLogs` function in `bottools/tokens.go` has been updated to accept a `crtTime` parameter, which is used to offset the token generation times based on the contract creation timestamp.