### PR TITLE
feat(boost): Reorder boosters based on token value and position

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -203,6 +203,7 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			b.TokensReceived += count
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: fromUserID, ToNick: contract.Boosters[fromUserID].Nick, Serial: xid.New().String()})
 			contract.mutex.Unlock()
+			reorderBoosters(contract)
 		}
 		if b.TokensReceived == b.TokensWanted {
 			b.BoostingTokenTimestamp = time.Now()


### PR DESCRIPTION
The changes made in this commit focus on the reordering of boosters in a contract based on their token value and position. The key changes are:

1. Added a new `position` field to the `TValPair` struct to track the position of each booster.
2. Implemented a new sorting logic that considers the booster's position (Sink First Boost, Sink Last Boost, or Follow Order) in addition to the token value.
3. Moved the logic for resetting the booster state when the current booster is the Sink Boost to the `Boosting` function.
4. Added a call to `reorderBoosters` in the `buttonReactionToken` function to ensure the boosters are reordered after a token is received.

These changes aim to improve the handling of the Sink Boost feature and ensure that the boosters are properly reordered based on their token value and position within the contract.