### PR TITLE
feat: Improve formatting and readability of coop status output

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -681,13 +681,6 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 
 	table := tablewriter.NewWriter(&builder)
 
-	//table.SetCenterSeparator("")
-	//table.SetColumnSeparator("")
-	//table.SetRowSeparator("")
-	//table.SetHeaderLine(false)
-	//table.SetTablePadding(" ") // pad with tabs
-	//table.SetNoWhiteSpace(true)
-	//table.SetAlignment(tablewriter.ALIGN_LEFT)
 	needLegend := false
 	showGlitch := false
 

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -416,9 +416,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		if len(BuffTimeValues) == 0 {
 			teamwork.WriteString("**No buffs found for this contract.**\n")
 		} else {
-			teamworkFmtHdr := "`%10s %10s %3s %4s %6s %-8s`\n"
-			teamworkFm := "`%10s %10s %3s %4s %6s %8s`\n"
-			fmt.Fprintf(&teamwork, teamworkFmtHdr, "  Time  ", "Duration", "Def", "SIAB", "BTV", "TeamWork")
+			teamworkFmtHdr := "%10s %10s %3s %4s %6s %-8s\n"
+			teamworkFm := "%10s %10s %3s %4s %6s %8s\n"
+			fmt.Fprintf(&teamwork, teamworkFmtHdr, "  TIME  ", "DURATION", "DEF", "SIAB", "BTV", "TEAMWORK")
 
 			BestSIAB := 0.0
 			LastSIAB := 0.0
@@ -493,7 +493,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			} else {
 				field = append(field, &discordgo.MessageEmbedField{
 					Name:   "Teamwork",
-					Value:  teamworkStr,
+					Value:  "```" + teamworkStr + "```",
 					Inline: false,
 				})
 			}
@@ -611,9 +611,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			}
 
 			var deliv strings.Builder
-			deliveryFmtHdr := "`%7s %10s %10s %7s %8s`\n"
-			deliveryFmt := "`%7s %10s %10s %7s %8s`\n"
-			fmt.Fprintf(&deliv, deliveryFmtHdr, "Type", "  Time   ", "Duration", "Rate/HR", "Contrib")
+			deliveryFmtHdr := "%7s %10s %10s %7s %8s\n"
+			deliveryFmt := "%7s %10s %10s %7s %8s\n"
+			fmt.Fprintf(&deliv, deliveryFmtHdr, "TYPE", "  TIME   ", "DURATION", "RATE/HR", "CONTRIB")
 			for _, d := range deliveryTableMap[name] {
 				fmt.Fprintf(&deliv, deliveryFmt,
 					d.name,
@@ -626,7 +626,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 
 			field = append(field, &discordgo.MessageEmbedField{
 				Name:   "Deliveries",
-				Value:  deliv.String(),
+				Value:  "```" + deliv.String() + "```",
 				Inline: false,
 			})
 


### PR DESCRIPTION
This commit focuses on improving the formatting and readability of the coop status output in the `stones.go` and `teamwork.go` files.

The key changes are:

- Removed unnecessary commented-out code in `stones.go` that was configuring the table writer.
- Wrapped the "Deliveries" and "Teamwork" values in code blocks (`````) in `teamwork.go` to make them more readable.
- Improve