### PR TITLE
feat: Ensure user is in contract before processing boost

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -226,6 +226,11 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 
 func buttonReactionLast(s *discordgo.Session, GuildID string, ChannelID string, contract *Contract, cUserID string) (bool, bool) {
 	var uid = cUserID
+	// make sure uid is in the contract
+	if !userInContract(contract, uid) {
+		return false, false
+	}
+
 	switch contract.Boosters[uid].BoostState {
 	case BoostStateTokenTime:
 		currentBoosterPosition := findNextBooster(contract)


### PR DESCRIPTION
This change ensures that the user ID provided is actually part of the
contract before processing the boost state. This prevents potential
issues where a user not in the contract could attempt to interact with
the boost functionality.