### PR TITLE
feat(boost): update token tracking and display

### DIFF
--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -548,6 +548,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 	c.mutex.Unlock()
 	track.ContractTokenUpdate(s, i.ChannelID, &modifiedTokenLog)
 	saveData(Contracts)
+	RedrawBoostList(s, i.GuildID, i.ChannelID)
 	return str
 }
 

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -50,16 +50,18 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 		if cUserID == b.UserID {
 			// Current booster subtract number of tokens wanted
 			log.Printf("Sink indicating they are boosting with %d tokens.\n", b.TokensWanted)
-			sink.TokensReceived -= b.TokensWanted
-			sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens
+			//	sink.TokensReceived -= b.TokensWanted
+			//	sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens
+			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: b.TokensWanted, FromUserID: cUserID, FromNick: contract.Boosters[cUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: xid.New().String()})
+			sink.TokensReceived = getTokensReceivedFromLog(contract, sink.UserID) - getTokensSentFromLog(contract, sink.UserID)
 		} else {
 			log.Printf("Sink sent %d tokens to booster\n", b.TokensWanted)
 			// Current booster number of tokens wanted
 			// How many tokens does booster want?  Check to see if sink has that many
 			tokensToSend := b.TokensWanted // If Sink is pressing 💰 they are assumed to be sending that many
 			b.TokensReceived += tokensToSend
-			sink.TokensReceived -= tokensToSend
-			sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens
+			sink.TokensReceived = getTokensReceivedFromLog(contract, sink.UserID) - getTokensSentFromLog(contract, sink.UserID)
+			//sink.TokensReceived = max(0, sink.TokensReceived) // Avoid missing self farmed tokens
 			// Record the Tokens as received
 			tokenSerial := xid.New().String()
 			now := time.Now()


### PR DESCRIPTION
The changes made in this commit focus on improving the token tracking and display functionality in the boost system. The key changes are:

1. Replaced the direct manipulation of `sink.TokensReceived` with a more robust approach that uses a token log to track token movements. This ensures that the token balance is accurately maintained, even in cases where tokens are self-farmed.

2. Introduced two new functions, `getTokensReceivedFromLog` and `getTokensSentFromLog`, to calculate the total tokens received and sent by a user based on the token log.

3. Updated the `getSinkIcon` function to use the new token log-based calculations to display the correct token balance for the current banker.

4. Improved the `DrawBoostList` function to use the new token log-based calculations to display the correct token balance for each booster, regardless of their boost state.

5. Added a call to `RedrawBoostList` in the `HandleTokenEditCommand` function to ensure that the boost list is updated after a token edit.

These changes aim to provide a more reliable and transparent token tracking system, improving the overall user experience and the accuracy of the boost system.