### PR TITLE
feat(boost): handle error from RedrawBoostList

### DIFF
--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -548,7 +548,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 	c.mutex.Unlock()
 	track.ContractTokenUpdate(s, i.ChannelID, &modifiedTokenLog)
 	saveData(Contracts)
-	RedrawBoostList(s, i.GuildID, i.ChannelID)
+	_ = RedrawBoostList(s, i.GuildID, i.ChannelID)
 	return str
 }
 


### PR DESCRIPTION
Handles the error returned from RedrawBoostList by ignoring it.
This ensures that the function can continue to execute even if
there is an issue with redrawing the boost list.