### PR TITLE
feat: Optimize EI data expiration and improve buff time calculation

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -391,14 +391,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		for _, a := range c.GetBuffHistory() {
 			earnings := int(math.Round(a.GetEarnings()*100 - 100))
 			eggRate := int(math.Round(a.GetEggLayingRate()*100 - 100))
-			serverTimestamp := a.GetServerTimestamp() // When it was equipped
-			if coopStatus.GetSecondsSinceAllGoalsAchieved() > 0 {
-				serverTimestamp -= coopStatus.GetSecondsSinceAllGoalsAchieved()
-			} else {
-				serverTimestamp += calcSecondsRemaining
-			}
-			serverTimestamp = contractDurationSeconds - serverTimestamp
-			BuffTimeValues = append(BuffTimeValues, BuffTimeValue{name, earnings, 0.0075 * float64(earnings), eggRate, 0.0075 * float64(eggRate) * 10.0, serverTimestamp, 0, 0, 0, 0})
+			// Equiptime is relative to the estimated end of the contract
+			equipTimestamp := contractDurationSeconds - (a.GetServerTimestamp() - coopStatus.GetSecondsSinceAllGoalsAchieved() + calcSecondsRemaining)
+			BuffTimeValues = append(BuffTimeValues, BuffTimeValue{name, earnings, 0.0075 * float64(earnings), eggRate, 0.0075 * float64(eggRate) * 10.0, equipTimestamp, 0, 0, 0, 0})
 		}
 
 		// From the last equipped buff, calculate the time until the end of the contract
@@ -611,8 +606,8 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			}
 
 			var deliv strings.Builder
-			deliveryFmtHdr := "%7s %10s %10s %7s %8s\n"
-			deliveryFmt := "%7s %10s %10s %7s %8s\n"
+			deliveryFmtHdr := "%9s %10s %10s %7s %8s\n"
+			deliveryFmt := "%9s %10s %10s %7s %8s\n"
 			fmt.Fprintf(&deliv, deliveryFmtHdr, "TYPE", "  TIME   ", "DURATION", "RATE/HR", "CONTRIB")
 			for _, d := range deliveryTableMap[name] {
 				fmt.Fprintf(&deliv, deliveryFmt,

--- a/src/ei/coop_status.go
+++ b/src/ei/coop_status.go
@@ -111,7 +111,7 @@ func GetCoopStatus(contractID string, coopID string) (*ContractCoopStatusRespons
 		}
 		//dataTimestampStr = ""
 		protoData = string(body)
-		data := eiData{ID: cacheID, timestamp: time.Now(), expirationTimestamp: time.Now().Add(1 * time.Minute), contractID: contractID, coopID: coopID, protoData: protoData}
+		data := eiData{ID: cacheID, timestamp: time.Now(), expirationTimestamp: time.Now().Add(30 * time.Second), contractID: contractID, coopID: coopID, protoData: protoData}
 		eiDatas[cacheID] = &data
 
 		// Save protoData into a file


### PR DESCRIPTION
This commit includes two main changes:

1. Reduce the expiration time for EI data from 1 minute to 30 seconds. This helps to keep the cache more up-to-date and responsive to changes in the cooperative status.

2. Improve the calculation of buff time values by using the estimated end of the contract as the reference point, rather than the server timestamp. This ensures that the buff time values are displayed correctly, even when the contract has been running for some time.