### PR TITLE
feat: Optimize contract duration calculation and buff time value

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -1062,8 +1062,8 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 		if coopStatus.GetSecondsSinceAllGoalsAchieved() > 0 {
 			startTime = startTime.Add(time.Duration(secondsRemaining) * time.Second)
 			startTime = startTime.Add(-time.Duration(eiContract.Grade[grade].LengthInSeconds) * time.Second)
-			secondsSinceAllGoals := int64(coopStatus.GetSecondsSinceAllGoalsAchieved())
-			endTime = endTime.Add(-time.Duration(secondsSinceAllGoals) * time.Second)
+			calcSecondsRemaining = -coopStatus.GetSecondsSinceAllGoalsAchieved()
+			endTime = endTime.Add(time.Duration(calcSecondsRemaining) * time.Second)
 			contractDurationSeconds = endTime.Sub(startTime).Seconds()
 		} else {
 			startTime = startTime.Add(time.Duration(secondsRemaining) * time.Second)
@@ -1100,13 +1100,8 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 	for _, c := range coopStatus.GetContributors() {
 		if len(c.GetBuffHistory()) > 0 {
 			a := c.GetBuffHistory()[0]
-			serverTimestamp := a.GetServerTimestamp() // When it was equipped
-			if coopStatus.GetSecondsSinceAllGoalsAchieved() > 0 {
-				serverTimestamp -= coopStatus.GetSecondsSinceAllGoalsAchieved()
-			} else {
-				serverTimestamp += calcSecondsRemaining
-			}
-			BuffTimeValueCRT = append(BuffTimeValueCRT, contractDurationSeconds-serverTimestamp)
+			equipTimestamp := a.GetServerTimestamp() + calcSecondsRemaining // When it was equipped
+			BuffTimeValueCRT = append(BuffTimeValueCRT, contractDurationSeconds-equipTimestamp)
 		}
 	}
 	if len(BuffTimeValueCRT) > 1 {

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -189,7 +189,6 @@ func HandleTeamworkEvalCommand(s *discordgo.Session, i *discordgo.InteractionCre
 			delete(teamworkCacheMap, key)
 		}
 	}
-
 }
 
 // DownloadCoopStatusTeamwork will download the coop status for a given contract and coop ID
@@ -409,7 +408,14 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		} else {
 			teamworkFmtHdr := "%10s %10s %3s %4s %6s %-8s\n"
 			teamworkFm := "%10s %10s %3s %4s %6s %8s\n"
-			fmt.Fprintf(&teamwork, teamworkFmtHdr, "  TIME  ", "DURATION", "DEF", "SIAB", "BTV", "TEAMWORK")
+			fmt.Fprintf(&teamwork, teamworkFmtHdr,
+				bottools.AlignString("TIME", 10, bottools.StringAlignCenter),
+				bottools.AlignString("DURATION", 10, bottools.StringAlignCenter),
+				bottools.AlignString("DEF", 3, bottools.StringAlignCenter),
+				bottools.AlignString("SIAB", 4, bottools.StringAlignCenter),
+				bottools.AlignString("BTV", 6, bottools.StringAlignRight),
+				bottools.AlignString("TEAMWORK", 8, bottools.StringAlignRight),
+			)
 
 			BestSIAB := 0.0
 			LastSIAB := 0.0
@@ -441,12 +447,13 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 				LastSIABCalc = float64(b.durationEquiped) * b.earningsCalc
 
 				fmt.Fprintf(&teamwork, teamworkFm,
-					fmt.Sprintf("%v", when.Round(time.Second)),
-					fmt.Sprintf("%v", dur.Round(time.Second)),
-					fmt.Sprintf("%d%%", b.eggRate),
-					fmt.Sprintf("%d%%", b.earnings),
-					fmt.Sprintf("%6.0f", b.buffTimeValue),
-					fmt.Sprintf("%1.6f", segmentTeamworkScore))
+					bottools.AlignString(fmt.Sprintf("%v", when.Round(time.Second)), 10, bottools.StringAlignCenter),
+					bottools.AlignString(fmt.Sprintf("%v", dur.Round(time.Second)), 10, bottools.StringAlignCenter),
+					bottools.AlignString(fmt.Sprintf("%d%%", b.eggRate), 3, bottools.StringAlignRight),
+					bottools.AlignString(fmt.Sprintf("%d%%", b.earnings), 4, bottools.StringAlignRight),
+					bottools.AlignString(fmt.Sprintf("%6.0f", b.buffTimeValue), 6, bottools.StringAlignRight),
+					bottools.AlignString(fmt.Sprintf("%1.6f", segmentTeamworkScore), 8, bottools.StringAlignRight),
+				)
 				buffTimeValue += b.buffTimeValue
 			}
 
@@ -456,8 +463,8 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			TeamworkScore := getPredictedTeamwork(B, 0.0, 0.0)
 			fmt.Fprintf(&teamwork, teamworkFm,
 				"", "", "", "",
-				fmt.Sprintf("%6.0f", buffTimeValue),
-				fmt.Sprintf("%1.6f", TeamworkScore))
+				bottools.AlignString(fmt.Sprintf("%6.0f", buffTimeValue), 6, bottools.StringAlignRight),
+				bottools.AlignString(fmt.Sprintf("%1.6f", TeamworkScore), 8, bottools.StringAlignRight))
 
 			// If the teamwork segment
 			teamworkStr := teamwork.String()
@@ -604,14 +611,20 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			var deliv strings.Builder
 			deliveryFmtHdr := "%9s %10s %10s %7s %8s\n"
 			deliveryFmt := "%9s %10s %10s %7s %8s\n"
-			fmt.Fprintf(&deliv, deliveryFmtHdr, "TYPE", "  TIME   ", "DURATION", "RATE/HR", "CONTRIB")
+			fmt.Fprintf(&deliv, deliveryFmtHdr,
+				bottools.AlignString("TYPE", 9, bottools.StringAlignCenter),
+				bottools.AlignString("TIME", 10, bottools.StringAlignCenter),
+				bottools.AlignString("DURATION", 10, bottools.StringAlignCenter),
+				bottools.AlignString("RATE/HR", 7, bottools.StringAlignCenter),
+				bottools.AlignString("CONTRIB", 8, bottools.StringAlignCenter),
+			)
 			for _, d := range deliveryTableMap[name] {
 				fmt.Fprintf(&deliv, deliveryFmt,
-					d.name,
-					d.timeEquipped.Sub(startTime).Round(time.Second).String(),
-					fmt.Sprintf("%v", d.duration.Round(time.Second)),
-					fmt.Sprintf("%2.3fq", (d.contributionRateInSeconds*3600)/1e15),
-					fmt.Sprintf("%2.3fq", d.contributions/1e15),
+					bottools.AlignString(d.name, 9, bottools.StringAlignCenter),
+					bottools.AlignString(d.timeEquipped.Sub(startTime).Round(time.Second).String(), 10, bottools.StringAlignCenter),
+					bottools.AlignString(fmt.Sprintf("%v", d.duration.Round(time.Second)), 10, bottools.StringAlignCenter),
+					bottools.AlignString(fmt.Sprintf("%2.3fq", (d.contributionRateInSeconds*3600)/1e15), 7, bottools.StringAlignCenter),
+					bottools.AlignString(fmt.Sprintf("%2.3fq", d.contributions/1e15), 8, bottools.StringAlignCenter),
 				)
 			}
 

--- a/src/bottools/utils.go
+++ b/src/bottools/utils.go
@@ -66,3 +66,39 @@ func SanitizeStringDuration(s string) string {
 
 	return days + hours + minutes + seconds
 }
+
+// StringAlign is an enum for string alignment
+type StringAlign int
+
+const (
+	// StringAlignLeft aligns the string to the left
+	StringAlignLeft StringAlign = iota
+	// StringAlignCenter aligns the string to the center
+	StringAlignCenter
+	// StringAlignRight aligns the string to the right
+	StringAlignRight
+)
+
+// AlignString aligns a string to the left, center, or right within a given width
+func AlignString(str string, width int, alignment StringAlign) string {
+	// Calculate the padding needed
+	padding := width - len(str)
+	if padding <= 0 {
+		return str
+	}
+
+	var leftPadding, rightPadding string
+	switch alignment {
+	case StringAlignLeft:
+		leftPadding = ""
+		rightPadding = strings.Repeat(" ", padding)
+	case StringAlignCenter:
+		leftPadding = strings.Repeat(" ", padding/2)
+		rightPadding = strings.Repeat(" ", padding-padding/2)
+	case StringAlignRight:
+		leftPadding = strings.Repeat(" ", padding)
+		rightPadding = ""
+	}
+
+	return leftPadding + str + rightPadding
+}


### PR DESCRIPTION
The changes in this commit focus on optimizing the calculation of contract duration and buff time value in the `stones.go` file. The key changes are:

1. Correctly calculate the `calcSecondsRemaining` value by using the `GetSecondsSinceAllGoalsAchieved()` method from the `coopStatus` object.
2. Update the calculation of `BuffTimeValueCRT` to use the correct `equipTimestamp` value, which is the original server timestamp plus the `calcSecondsRemaining`.

These changes ensure that the contract duration and buff time value are calculated accurately, which is crucial for the correct display of teamwork information.

Additionally, the changes in `teamwork.go` improve the formatting and alignment of the teamwork output, making it more readable and visually appealing.