### PR TITLE
feat(stones_pages): Update cache and estimate time

### DIFF
--- a/src/boost/stones_pages.go
+++ b/src/boost/stones_pages.go
@@ -96,6 +96,10 @@ func sendStonesPage(s *discordgo.Session, i *discordgo.InteractionCreate, newMes
 		cache = newCache
 		stonesCacheMap[cache.xid] = newCache
 
+		contract := FindContract(i.ChannelID)
+		if contract != nil {
+			go updateEstimatedTime(s, i.ChannelID, contract, false)
+		}
 		//delete(stonesCacheMap, xid)
 		//exists = false
 	}


### PR DESCRIPTION
Updates the stones cache and triggers an update to the estimated
time for the channel. This ensures the estimated time is kept
up-to-date as the cache is updated.