### PR TITLE
feat: update contract start time and duration

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1919,3 +1919,19 @@ func ArchiveContracts(s *discordgo.Session) {
 
 	track.ArchiveTrackerData(s)
 }
+
+// UpdateContractTime will update the contract start time and estimated duration
+func UpdateContractTime(contractID string, coopID string, startTime time.Time, contractDurationSeconds float64) {
+	// Update the contract start time and estimated duration
+	contract := findContractByIDs(contractID, coopID)
+	if contract == nil {
+		return
+	}
+	// Only update if startTime or EstimatedDuration are different
+	newDuration := time.Duration(contractDurationSeconds) * time.Second
+	if !contract.StartTime.Equal(startTime) || contract.EstimatedDuration != newDuration {
+		contract.StartTime = startTime
+		contract.EstimatedDuration = newDuration
+		contract.EstimateUpdateTime = time.Now()
+	}
+}

--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -156,6 +156,14 @@ func HandleStonesCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	s1, urls, tiles := DownloadCoopStatusStones(contractID, coopID, details, soloName, useBuffHistory)
 
+	contract := findContractByIDs(contractID, coopID)
+	if contract != nil {
+		// Only refresh if EstimateUpdateTime is within 10 seconds of now
+		if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
+			refreshBoostListMessage(s, contract)
+		}
+	}
+
 	if tiles != nil {
 		cache := buildStonesCache(s1, urls, tiles)
 		// Fill in our calling parameters
@@ -1105,6 +1113,9 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 				}
 			}
 		}
+
+		UpdateContractTime(coopStatus.GetContractIdentifier(), coopStatus.GetCoopIdentifier(), startTime, contractDurationSeconds)
+
 		builder.WriteString(fmt.Sprintf("Start: **<t:%d:t>**   %s: **<t:%d:t>** for **%v**\n", startTime.Unix(), endStr, endTime.Unix(), endTime.Sub(startTime).Round(time.Second)))
 		if eiContract.ModifierELR != 1.0 {
 			fmt.Fprintf(&builder, "ELR Modifier: %2.1fx\n", eiContract.ModifierELR)

--- a/src/boost/stones_pages.go
+++ b/src/boost/stones_pages.go
@@ -96,13 +96,14 @@ func sendStonesPage(s *discordgo.Session, i *discordgo.InteractionCreate, newMes
 		cache = newCache
 		stonesCacheMap[cache.xid] = newCache
 
-		/*contract := FindContract(i.ChannelID)
+		contract := findContractByIDs(cache.contractID, cache.coopID)
 		if contract != nil {
-			go updateEstimatedTime(s, i.ChannelID, contract, false)
+			// Only refresh if EstimateUpdateTime is within 10 seconds of now
+			if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
+				refreshBoostListMessage(s, contract)
+			}
 		}
-		*/
-		//delete(stonesCacheMap, xid)
-		//exists = false
+
 	}
 
 	if !exists {

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -286,6 +286,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		contractDurationSeconds = endTime.Sub(startTime).Seconds()
 		builder.WriteString(fmt.Sprintf("In Progress %s %s/[**%s**](%s) on target to complete <t:%d:R>\n", ei.GetBotEmojiMarkdown("contract_grade_"+ei.GetContractGradeString(grade)), contractID, coopID, fmt.Sprintf("%s/%s/%s", "https://eicoop-carpet.netlify.app", contractID, coopID), endTime.Unix()))
 	}
+
+	UpdateContractTime(coopStatus.GetContractIdentifier(), coopStatus.GetCoopIdentifier(), startTime, contractDurationSeconds)
+
 	builder.WriteString(fmt.Sprintf("Start Time: <t:%d:f>\n", startTime.Unix()))
 	builder.WriteString(fmt.Sprintf("%sEnd Time: <t:%d:f>\n", prefix, endTime.Unix()))
 	builder.WriteString(fmt.Sprintf("%sDuration: %v\n", prefix, (endTime.Sub(startTime)).Round(time.Second)))


### PR DESCRIPTION
This change updates the contract start time and estimated duration in the contract
object when the contract status is updated. This ensures that the contract
information displayed in the boost list message is accurate and up-to-date.

The key changes are:

- Added a new `UpdateContractTime` function to update the contract start time and
  estimated duration
- Updated the `teamwork.go` and `stones.go` files to call the `UpdateContractTime`
  function when the contract status is updated
- Added a check to only refresh the boost list message if the `EstimateUpdateTime`
  is within 10 seconds of the current time, to avoid unnecessary updates