### PR TITLE
feat(boost): Optimize boost list refresh logic

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -158,12 +158,13 @@ func HandleStonesCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	contract := findContractByIDs(contractID, coopID)
 	if contract != nil {
-		// Only refresh if EstimateUpdateTime is within 10 seconds of now
-		if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
-			refreshBoostListMessage(s, contract)
+		if contract.State == ContractStateCompleted {
+			// Only refresh if EstimateUpdateTime is within 10 seconds of now
+			if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
+				refreshBoostListMessage(s, contract)
+			}
 		}
 	}
-
 	if tiles != nil {
 		cache := buildStonesCache(s1, urls, tiles)
 		// Fill in our calling parameters

--- a/src/boost/stones_pages.go
+++ b/src/boost/stones_pages.go
@@ -98,9 +98,11 @@ func sendStonesPage(s *discordgo.Session, i *discordgo.InteractionCreate, newMes
 
 		contract := findContractByIDs(cache.contractID, cache.coopID)
 		if contract != nil {
-			// Only refresh if EstimateUpdateTime is within 10 seconds of now
-			if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
-				refreshBoostListMessage(s, contract)
+			if contract.State == ContractStateCompleted {
+				// Only refresh if EstimateUpdateTime is within 10 seconds of now
+				if math.Abs(time.Since(contract.EstimateUpdateTime).Seconds()) <= 10 {
+					refreshBoostListMessage(s, contract)
+				}
 			}
 		}
 


### PR DESCRIPTION
The changes made in this commit optimize the boost list refresh logic by
only refreshing the list if the contract is in the completed state and the
EstimateUpdateTime is within 10 seconds of the current time. This helps
to reduce unnecessary API calls and improve the overall performance of
the application.