### PR TITLE
feat(contracts): Update contract time only for completed contracts

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1924,9 +1924,10 @@ func ArchiveContracts(s *discordgo.Session) {
 func UpdateContractTime(contractID string, coopID string, startTime time.Time, contractDurationSeconds float64) {
 	// Update the contract start time and estimated duration
 	contract := findContractByIDs(contractID, coopID)
-	if contract == nil {
+	if contract == nil || contract.State != ContractStateCompleted {
 		return
 	}
+
 	// Only update if startTime or EstimatedDuration are different
 	newDuration := time.Duration(contractDurationSeconds) * time.Second
 	if !contract.StartTime.Equal(startTime) || contract.EstimatedDuration != newDuration {


### PR DESCRIPTION
The changes made in this commit update the `UpdateContractTime` function to
only update the contract start time and estimated duration if the contract
is in the `ContractStateCompleted` state. This ensures that the function
does not attempt to update contracts that are not in the completed state,
which could lead to unexpected behavior.