### PR TITLE
feat(teamwork): Ensure contribution rate is non-negative

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -377,7 +377,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		})
 
 		// Determine the contribution rate for the user
-		futureDeliveries := c.GetContributionRate() * float64(calcSecondsRemaining)
+		futureDeliveries := c.GetContributionRate() * math.Max(0, float64(calcSecondsRemaining))
 		contributionPast := c.GetContributionAmount()
 		offlineDeliveries := -c.GetFarmInfo().GetTimestamp() * c.GetContributionRate()
 		if coopStatus.GetSecondsSinceAllGoalsAchieved() > 0 {


### PR DESCRIPTION
Modify the calculation of `futureDeliveries` to ensure that the
contribution rate is never negative, even when the remaining time is
less than zero. This prevents the contribution amount from being
incorrectly reduced when the coop has already achieved its goals.