### PR TITLE
feat(teamwork): Add projected contract scores to coop status

### DIFF
--- a/src/boost/teamwork_pages.go
+++ b/src/boost/teamwork_pages.go
@@ -106,7 +106,7 @@ func sendTeamworkPage(s *discordgo.Session, i *discordgo.InteractionCreate, newM
 
 	if exists && (refresh || cache.expirationTimestamp.Before(time.Now())) {
 
-		s1, fields := DownloadCoopStatusTeamwork(cache.contractID, cache.coopID, 0)
+		s1, fields, _ := DownloadCoopStatusTeamwork(cache.contractID, cache.coopID, 0)
 		newCache := buildTeamworkCache(s1, fields)
 
 		newCache.public = cache.public


### PR DESCRIPTION
This change adds the projected contract scores to the coop status message. The scores are displayed in a table format, showing the maximum, sink, runs, and base scores for each farmer in the coop.

The changes include:

- Modify the `DownloadCoopStatusTeamwork` function to return the projected contract scores as a string.
- Add a new section to the coop status message that displays the projected contract scores.
- Sort the contract scores by the maximum score and format them in a table layout.
- Add a footer to the message that explains the different score types.

These changes provide more detailed information to the users about the projected contract performance, which can help them make informed decisions about their participation in the contract.