### PR TITLE
feat(teamwork): Fetch user name for farmer field display

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -761,7 +761,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 				Inline: false,
 			})
 			farmerFields[name] = field
-			trimmedName := name
+			trimmedName := c.GetUserName()
 			if len(trimmedName) > 12 {
 				trimmedName = trimmedName[:12]
 			}


### PR DESCRIPTION
Fetch the user's name instead of using the field name for the
farmer field display. This ensures a consistent and more
informative display of the farmer's name in the UI.