### PR TITLE
feat(discord): Improve contract score estimate description

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -11,7 +11,7 @@ func GetSlashCsEstimates(cmd string) *discordgo.ApplicationCommand {
 	return &discordgo.ApplicationCommand{
 		Name: cmd,
 
-		Description: "Provide an estimate of the scores for a running contract",
+		Description: "Provide a Contract Score estimates for a running contract",
 		Contexts: &[]discordgo.InteractionContextType{
 			discordgo.InteractionContextGuild,
 			discordgo.InteractionContextBotDM,


### PR DESCRIPTION
Modify the description of the "Provide an estimate of the scores for a
running contract" Discord command to be more concise and informative.
The new description "Provide a Contract Score estimates for a running
contract" better reflects the purpose of the command.