### PR TITLE
feat(boost): remove unused TargetAmountq field

### DIFF
--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -128,7 +128,6 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 		//		if grade == ei.Contract_GRADE_AAA {
 		for _, g := range s.GetGoals() {
 			c.TargetAmount = append(c.TargetAmount, g.GetTargetAmount())
-			c.TargetAmountq = append(c.TargetAmountq, g.GetTargetAmount()/1e15)
 			c.LengthInSeconds = int(s.GetLengthSeconds())
 		}
 		c.ModifierIHR = 1.0
@@ -165,7 +164,6 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 		}
 		//		}
 		c.Grade[grade].TargetAmount = c.TargetAmount
-		c.Grade[grade].TargetAmountq = c.TargetAmountq
 		c.Grade[grade].ModifierIHR = c.ModifierIHR
 		c.Grade[grade].ModifierELR = c.ModifierELR
 		c.Grade[grade].ModifierSR = c.ModifierSR
@@ -177,7 +175,7 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 		c.Grade[grade].ModifierResearchCost = c.ModifierResearchCost
 		c.Grade[grade].LengthInSeconds = c.LengthInSeconds
 
-		c.Grade[grade].EstimatedDuration, c.Grade[grade].EstimatedDurationLower = getContractDurationEstimate(c.TargetAmountq[len(c.TargetAmountq)-1], float64(c.MaxCoopSize), c.LengthInSeconds,
+		c.Grade[grade].EstimatedDuration, c.Grade[grade].EstimatedDurationLower = getContractDurationEstimate(c.TargetAmount[len(c.TargetAmount)-1], float64(c.MaxCoopSize), c.LengthInSeconds,
 			c.ModifierSR, c.ModifierELR, c.ModifierHabCap)
 
 		gradeKey := ei.Contract_PlayerGrade_name[int32(grade)]
@@ -206,11 +204,9 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 	}
 	if c.TargetAmount == nil {
 		c.TargetAmount = nil
-		c.TargetAmountq = nil
 		for _, g := range contractProtoBuf.GetGoals() {
 			c.ContractVersion = 1
 			c.TargetAmount = append(c.TargetAmount, g.GetTargetAmount())
-			c.TargetAmountq = append(c.TargetAmountq, g.GetTargetAmount()/1e15)
 		}
 		//log.Print("No target amount found for contract ", c.ID)
 	}
@@ -227,7 +223,7 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 				fmt.Printf("Coop Name: %s, ID: %s, Modifiers: IHR: %f, ELR: %f, SR: %f, HabCap: %f\n",
 					c.Name, c.ID, c.ModifierIHR, c.ModifierELR, c.ModifierSR, c.ModifierHabCap)
 			}*/
-		c.EstimatedDuration, c.EstimatedDurationLower = getContractDurationEstimate(c.TargetAmountq[len(c.TargetAmountq)-1], float64(c.MaxCoopSize), c.LengthInSeconds,
+		c.EstimatedDuration, c.EstimatedDurationLower = getContractDurationEstimate(c.TargetAmount[len(c.TargetAmount)-1], float64(c.MaxCoopSize), c.LengthInSeconds,
 			c.ModifierSR, c.ModifierELR, c.ModifierHabCap)
 	}
 	return c
@@ -244,7 +240,6 @@ func updateContractWithEggIncData(contract *Contract) {
 			contract.Description = cc.Description
 			contract.EggName = cc.EggName
 			contract.TargetAmount = cc.TargetAmount
-			contract.QTargetAmount = cc.TargetAmountq
 			contract.ChickenRunCooldownMinutes = cc.ChickenRunCooldownMinutes
 			contract.MinutesPerToken = cc.MinutesPerToken
 			contract.Ultra = cc.Ultra

--- a/src/boost/estimate_time.go
+++ b/src/boost/estimate_time.go
@@ -173,11 +173,14 @@ func getContractEstimateString(contractID string) string {
 			ei.GetBotEmojiMarkdown("egg_pumpkin"))
 	*/
 	// A speedrun or fastrun of $CONTRACT with $NUMBER farmer(s) needing to ship $GOAL eggs is estimated to take about $TIME
-	if c.TargetAmountq[len(c.TargetAmountq)-1] < 1.0 {
-		str += fmt.Sprintf("**%v** - **%v** for a fastrun needing to ship **%.3fq** eggs\n", estStrLower, estStr, float64(c.TargetAmountq[len(c.TargetAmountq)-1]))
-	} else {
-		str += fmt.Sprintf("**%v** - **%v** for a fastrun needing to ship **%.dq** eggs\n", estStrLower, estStr, int(c.TargetAmountq[len(c.TargetAmountq)-1]))
+	options := map[string]any{
+		"decimals": 2,
+		"trim":     true,
 	}
+	str += fmt.Sprintf("**%v** - **%v** for a fastrun needing to ship **%s** eggs\n",
+		estStrLower,
+		estStr,
+		ei.FormatEIValue(c.TargetAmount[len(c.TargetAmount)-1], options))
 
 	if c.ContractVersion == 2 {
 		// Two ranges of estimates
@@ -226,7 +229,7 @@ func getContractEstimateString(contractID string) string {
 }
 
 // getContractDurationEstimate returns two estimated durations of a contract based for great and well equiped artifact sets
-func getContractDurationEstimate(contractEggsInSmallQ float64, numFarmers float64, contractLengthInSeconds int, modifierSR float64, modifierELR float64, modifierHabCap float64) (time.Duration, time.Duration) {
+func getContractDurationEstimate(contractEggsTotal float64, numFarmers float64, contractLengthInSeconds int, modifierSR float64, modifierELR float64, modifierHabCap float64) (time.Duration, time.Duration) {
 
 	contractDuration := time.Duration(contractLengthInSeconds) * time.Second
 
@@ -278,7 +281,7 @@ func getContractDurationEstimate(contractEggsInSmallQ float64, numFarmers float6
 		tachMultiplier := math.Pow(1.05, tachBounded)
 		contractELR := contractBaseELR * deflectorMultiplier * tachMultiplier
 		boundedELR := min(contractShipCap, contractELR)
-		estimate := 0.75 + contractEggsInSmallQ/(numFarmers*boundedELR)
+		estimate := 0.75 + (contractEggsTotal/1e15)/(numFarmers*boundedELR)
 
 		if est.slots == 8.0 {
 			estimateDurationUpper = time.Duration(estimate * float64(time.Hour))

--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -123,7 +123,6 @@ var GradeMultiplier = map[string]float64{
 // ContractGrade is a raw contract data for a Grade in Egg Inc
 type ContractGrade struct {
 	TargetAmount           []float64
-	TargetAmountq          []float64
 	LengthInSeconds        int
 	EstimatedDuration      time.Duration
 	EstimatedDurationLower time.Duration
@@ -155,7 +154,6 @@ type EggIncContract struct {
 	SeasonID                  string
 	MaxCoopSize               int
 	TargetAmount              []float64
-	TargetAmountq             []float64
 	ChickenRuns               int
 	LengthInSeconds           int
 	ChickenRunCooldownMinutes int

--- a/src/ei/ei_units.go
+++ b/src/ei/ei_units.go
@@ -89,7 +89,7 @@ func ParseValueWithUnit(s string, unitRequired bool) (float64, error) {
 	return value * math.Pow10(oom), nil
 }
 
-func FormatEIValue(x float64, options map[string]interface{}) string {
+func FormatEIValue(x float64, options map[string]any) string {
 	trim := options["trim"] == true
 	decimals := 3
 	if d, ok := options["decimals"].(int); ok {


### PR DESCRIPTION
The changes remove the unused `TargetAmountq` field from the `ContractGrade` and `Contract` structs. This field was previously used to store the target amount in quintillions, but it is no longer needed as the `TargetAmount` field already stores the target amount in the correct format.

The changes also update the `getContractDurationEstimate` function to use the `TargetAmount` field instead of the `TargetAmountq` field, and the `FormatEIValue` function to handle the formatting of the target amount.