### PR TITLE
feat(estimate_time): Improve contract time estimation

### DIFF
--- a/src/boost/estimate_time.go
+++ b/src/boost/estimate_time.go
@@ -281,7 +281,15 @@ func getContractDurationEstimate(contractEggsTotal float64, numFarmers float64, 
 		tachMultiplier := math.Pow(1.05, tachBounded)
 		contractELR := contractBaseELR * deflectorMultiplier * tachMultiplier
 		boundedELR := min(contractShipCap, contractELR)
-		estimate := 0.75 + (contractEggsTotal/1e15)/(numFarmers*boundedELR)
+
+		eggsTotal := contractEggsTotal / 1e15
+		estimate := eggsTotal / (numFarmers * boundedELR)
+		if float64(contractLengthInSeconds) < 45*60 {
+			// For small contracts, add less time padding for boosts
+			estimate += 0.30
+		} else {
+			estimate += 0.75
+		}
 
 		if est.slots == 8.0 {
 			estimateDurationUpper = time.Duration(estimate * float64(time.Hour))


### PR DESCRIPTION
Modify the contract time estimation logic to provide more accurate
estimates. The changes include:

- Separate the calculation of the eggs total from the estimate
  calculation to improve readability.
- Adjust the time padding added to the estimate based on the contract
  length. Shorter contracts receive less padding to account for the
  reduced impact of boosts.