### PR TITLE
feat(boost): Add new footer line for TVAL metric

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -109,6 +109,7 @@ func HandleCsEstimatesCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 	var footer strings.Builder
 	footer.WriteString("-# MAX : Max Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
+	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")
 	footer.WriteString("-# BASE: No Chicken Runs & No token sharing\n")
 	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{


### PR DESCRIPTION
Adds a new line to the footer of the estimate_scores.go file to
include information about the TVAL metric, which represents the
maximum number of chicken runs for a coop size minus 1, along with
the associated delta T-value.