### PR TITLE
feat(scores): Reorder score columns and update footer

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -108,8 +108,8 @@ func HandleCsEstimatesCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 
 	var footer strings.Builder
 	footer.WriteString("-# MAX : Max Chicken Runs & ∆T-Val\n")
-	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
 	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
+	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
 	footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")
 	footer.WriteString("-# BASE: No Chicken Runs & No token sharing\n")
 	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -166,6 +166,7 @@ func HandleTeamworkEvalCommand(s *discordgo.Session, i *discordgo.InteractionCre
 	if scoresFirst {
 		var footer strings.Builder
 		footer.WriteString("-# MAX : Max Chicken Runs & ∆T-Val\n")
+		footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 		footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
 		footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")
 		footer.WriteString("-# BASE: No Chicken Runs & No token sharing\n")
@@ -341,8 +342,8 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 	fmt.Fprintf(&scoresTable, "`%12s %6s %6s %6s %6s %6s`\n",
 		bottools.AlignString("NAME", 12, bottools.StringAlignCenter),
 		bottools.AlignString("MAX", 6, bottools.StringAlignCenter),
-		bottools.AlignString("SINK", 6, bottools.StringAlignCenter),
 		bottools.AlignString("TVAL", 6, bottools.StringAlignCenter),
+		bottools.AlignString("SINK", 6, bottools.StringAlignCenter),
 		bottools.AlignString("RUNS", 6, bottools.StringAlignCenter),
 		bottools.AlignString("BASE", 6, bottools.StringAlignCenter),
 	)
@@ -804,7 +805,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 	for _, cs := range contractScoreArr {
 		fmt.Fprintf(&scoresTable, "`%12s %6d %6d %6d %6d %6d`\n",
 			bottools.AlignString(cs.name, 12, bottools.StringAlignLeft),
-			cs.max, cs.sink, cs.tval, cs.runs, cs.base)
+			cs.max, cs.tval, cs.sink, cs.runs, cs.base)
 	}
 
 	var siabMax []*discordgo.MessageEmbedField


### PR DESCRIPTION
The changes made in this commit are:

1. Reordered the score columns in the scores table to display the "TVAL" column before the "SINK" column.
2. Updated the footer in the `estimate_scores.go` and `teamwork.go` files to reflect the new order of the score columns.

The motivation behind these changes is to improve the readability and consistency of the scores table by aligning the order of the score columns with the order presented in the footer.