### PR TITLE
feat: Update message components in boost and boost_speedrun

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1189,7 +1189,7 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 				})
 				components = append(components, comp...)
 				msg.Flags = discordgo.MessageFlagsIsComponentsV2
-				msg.Components = &comp
+				msg.Components = &components
 				_, _ = s.ChannelMessageEditComplex(msg)
 			}
 		}

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -558,7 +558,7 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkCrt string, 
 				Content: contentStr,
 			})
 			components = append(components, comp...)
-			msg.Components = &comp
+			msg.Components = &components
 			_, _ = s.ChannelMessageEditComplex(msg)
 		}
 	}


### PR DESCRIPTION
The changes update the message components in the `boost` and `boost_speedrun` modules. In both cases, the `msg.Components` field is updated to use the `components` slice instead of the `comp` slice. This ensures that all the components are properly included in the edited message.