### PR TITLE
feat(boost): Improve boost list message refresh

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -50,6 +50,7 @@ func getSinkIcon(contract *Contract, b *Booster) string {
 func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.MessageComponent {
 	var components []discordgo.MessageComponent
 	var builder strings.Builder
+	var targetTval float64
 	//var outputStr string
 	var afterListStr strings.Builder
 	tokenStr := contract.TokenStr
@@ -149,8 +150,8 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 				contract.EstimatedDuration = c.EstimatedDuration
 			}
 		}
-		tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-		builder.WriteString(fmt.Sprintf("> Current TVal: %2.3g\n", tval))
+		targetTval = bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+		builder.WriteString(fmt.Sprintf("> Current TVal: %2.3g\n", targetTval))
 	}
 
 	if !contract.EstimateUpdateTime.IsZero() {
@@ -528,6 +529,14 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 		}
 
 	case ContractStateCompleted:
+		coopTvalStr := calculateTokenValueCoopLog(contract, contract.EstimatedDuration, targetTval)
+		components = append(components, &discordgo.TextDisplay{
+			Content: coopTvalStr,
+		})
+		components = append(components, &discordgo.Separator{
+			Divider: &divider,
+			Spacing: &spacing,
+		})
 		t1 := contract.EndTime
 		t2 := contract.StartTime
 		duration := t1.Sub(t2)

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -548,7 +548,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 	c.mutex.Unlock()
 	track.ContractTokenUpdate(s, i.ChannelID, &modifiedTokenLog)
 	saveData(Contracts)
-	_ = RedrawBoostList(s, i.GuildID, i.ChannelID)
+	refreshBoostListMessage(s, c)
 	return str
 }
 


### PR DESCRIPTION
The changes in this commit focus on improving the refresh of the boost list message. The main changes are:

1. Replace the `RedrawBoostList` function call with a new `refreshBoostListMessage` function to update the boost list message.
2. In the `DrawBoostList` function, calculate the target token value (`targetTval`) and pass it to the function to display the cooperative token value.
3. Add a new section to the boost list message to display the cooperative token value for completed contracts.

These changes aim to provide a more accurate and informative boost list message for users.