### PR TITLE
feat(boost): Display target and current TVal in boost draw

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -156,7 +156,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 			}
 		}
 		currentTval = bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-		builder.WriteString(fmt.Sprintf("> Current TVal: %2.3g\n", currentTval))
+		builder.WriteString(fmt.Sprintf("> TVal: 🎯%2.2f  📉%2.2f\n", targetTval, currentTval))
 	}
 
 	if !contract.EstimateUpdateTime.IsZero() {

--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -110,7 +110,6 @@ func HandleCsEstimatesCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 	footer.WriteString("-# MAX : Max Chicken Runs & \n")
 	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
-	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")
 	footer.WriteString("-# BASE: No Chicken Runs & No token sharing\n")
 	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{


### PR DESCRIPTION
The changes in this commit improve the display of the current TVal in the boost draw
function. The previous implementation only showed the current TVal, but now it also
displays the target TVal for comparison. This provides more useful information to the
user about the progress of the boost.