### PR TITLE
feat: Update TVal display format

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -156,7 +156,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 			}
 		}
 		currentTval = bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-		builder.WriteString(fmt.Sprintf("> TVal: 🎯%2.2f  📉%2.2f\n", targetTval, currentTval))
+		builder.WriteString(fmt.Sprintf("> TVal: 🎯%2.2f 📉%2.2f\n", targetTval, currentTval))
 	}
 
 	if !contract.EstimateUpdateTime.IsZero() {


### PR DESCRIPTION
Modify the format of the TVal display in the boost_draw.go file.
The changes ensure that the TVal values are displayed with a consistent
format, making the output more readable and easier to interpret.