### PR TITLE
feat(boost): Add ∆T-Val to MAX score in estimate_scores.go

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -107,7 +107,7 @@ func HandleCsEstimatesCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 	}
 
 	var footer strings.Builder
-	footer.WriteString("-# MAX : Max Chicken Runs & \n")
+	footer.WriteString("-# MAX : Max Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
 	footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")


### PR DESCRIPTION
The changes add the ∆T-Val metric to the MAX score footer in the
estimate_scores.go file. This provides additional context for the MAX
score, which represents the maximum number of chicken runs.