### PR TITLE
feat: Improve egg laying rate calculation and display

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -672,7 +672,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 			lastDeflectorPercent := 0.0
 			for _, b := range c.BuffHistory {
 				if b.GetEggLayingRate() > 1.0 {
-					buffElr := (b.GetEggLayingRate() - 1.0) * 100.0
+					buffElr := math.Round((b.GetEggLayingRate() - 1.0) * 100.0)
 					if buffElr > bestDeflectorPercent {
 						bestDeflectorPercent = buffElr
 					}
@@ -688,8 +688,8 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 					everyoneDeflectorPercent += lastDeflectorPercent
 				}
 			} else if useBuffHistory {
-				as.note = append(as.note, fmt.Sprintf("DEFL from BuffHist %2.0f%%", math.Ceil(bestDeflectorPercent)))
-				as.deflector.abbrev = fmt.Sprintf("%2.0f%%", math.Ceil(bestDeflectorPercent))
+				as.note = append(as.note, fmt.Sprintf("DEFL from BuffHist %2.0f%%", bestDeflectorPercent))
+				as.deflector.abbrev = fmt.Sprintf("%2.0f%%", bestDeflectorPercent)
 				as.deflector.percent = bestDeflectorPercent
 				everyoneDeflectorPercent += as.deflector.percent
 			}


### PR DESCRIPTION
The changes in this commit improve the calculation and display of the egg
laying rate (ELR) deflector percentage. Specifically:

- The `buffElr` value is now rounded to the nearest integer using `math.Round()`
  instead of being truncated.
- The `as.note` and `as.deflector.abbrev` fields are now using the rounded
  `bestDeflectorPercent` value instead of `math.Ceil()`.

These changes ensure that the displayed deflector percentage is more accurate
and visually appealing.