### PR TITLE
feat: Optimize boost list component updates

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -388,7 +388,6 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 	reaction := strings.Split(i.MessageComponentData().CustomID, "#")
 	cmd := strings.ToLower(reaction[1])
 	contractHash := reaction[len(reaction)-1]
-	refreshBoostListComponents := false
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredMessageUpdate,
@@ -562,7 +561,6 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		}
 		if contract.State == ContractStateCompleted || contract.State == ContractStateWaiting {
 			contract.Banker.CurrentBanker = contract.Banker.PostSinkUserID
-			refreshBoostListComponents = true
 		}
 	case "sinkorder":
 		// toggle the sink order
@@ -585,19 +583,15 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		components = append(components, boostListComp...)
 
 		msgedit.Flags = discordgo.MessageFlagsIsComponentsV2
-		if refreshBoostListComponents {
-			comp := getContractReactionsComponents(contract)
-			components = append(components, comp...)
-		}
+		comp := getContractReactionsComponents(contract)
+		components = append(components, comp...)
 		msgedit.Components = &components
 
 		msg, err := s.ChannelMessageEditComplex(msgedit)
 		if err == nil {
 			loc.ListMsgID = msg.ID
 		}
-		//if refreshBoostListComponents {
-		//	addContractReactionsButtons(s, contract, loc.ChannelID, msg.ID)
-		//}
+
 		if redrawSignup {
 			// Rebuild the signup message to disable the start button
 			var components []discordgo.MessageComponent


### PR DESCRIPTION
The changes made in this commit optimize the update of the boost list components in the contract management system. The main changes are:

- Removed the `refreshBoostListComponents` flag, as it was not necessary to check for this flag before updating the components.
- Directly appended the updated contract reactions components to the message edit components, without any conditional checks.
- Removed the commented-out code that was adding the contract reactions buttons, as this functionality is now handled by the updated components.

These changes simplify the code and improve the efficiency of the boost list component updates, making the contract management system more robust and maintainable.