### PR TITLE
feat(periodicals): Add permissions check for ACO channel

### DIFF
--- a/src/bottools/banners.go
+++ b/src/bottools/banners.go
@@ -48,12 +48,13 @@ func GenerateBanner(ID string, eggName string, text string) {
 	outputImagePath := fmt.Sprintf("%s/b-%s.png", config.BannerOutputPath, ID)
 	// if the image already exists, return
 	if _, err := os.Stat(outputImagePath); err == nil {
-		fmt.Println("Image already exists:", outputImagePath)
+		//fmt.Println("Image already exists:", outputImagePath)
 		return
 	} else if !os.IsNotExist(err) {
 		fmt.Println("Error checking output image:", err)
 		return
 	}
+	log.Printf("Creating banner in %s", outputImagePath)
 	bgImagePath := config.BannerPath + "/banner.png"
 	cleanEggID := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(eggName), " ", ""), "-", "")
 	cleanEggID = strings.ReplaceAll(cleanEggID, "_", "")

--- a/src/events/periodicals.go
+++ b/src/events/periodicals.go
@@ -212,12 +212,21 @@ func GetPeriodicalsFromAPI(s *discordgo.Session) {
 
 			// Also send this for ACO
 			if !config.IsDevBot() {
-				_, err = s.ChannelMessageSendComplex("1257340301438222401", &data)
+				acoChannel := "1103074428352471050" // ACO #contracts-version-2-chat
+				permissions, err := s.UserChannelPermissions(config.DiscordAppID, acoChannel)
 				if err != nil {
-					log.Print(err)
+					log.Printf("Error getting permissions for channel %s: %v", acoChannel, err)
+				} else {
+					if permissions&discordgo.PermissionSendMessages == 0 {
+						log.Printf("Bot does not have permission to send messages in channel %s", acoChannel)
+					} else {
+						_, err = s.ChannelMessageSendComplex(acoChannel, &data)
+						if err != nil {
+							log.Print(err)
+						}
+					}
 				}
 			}
-
 		}
 
 		ei.CustomEggMap[egg.ID] = &egg


### PR DESCRIPTION
The changes in this commit add a permissions check for the ACO channel before sending a message. This ensures that the bot has the necessary permissions to send messages in the channel, and logs a warning if it does not. This is an important change to prevent errors and ensure the bot's functionality.