### PR TITLE
feat(banners): Add text outline effect to banner text

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -183,7 +183,7 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			track.ContractTokenMessage(s, ChannelID, fromUserID, track.TokenSent, count, b.Nick, tokenSerial, now)
 			contract.mutex.Lock()
 			b.TokensReceived += count
-			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: now, Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial})
+			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: now, Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial, Boost: false})
 			contract.mutex.Unlock()
 			if contract.BoostOrder == ContractOrderTVal {
 				tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
@@ -201,7 +201,7 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			track.FarmedToken(s, ChannelID, fromUserID, count)
 			contract.mutex.Lock()
 			b.TokensReceived += count
-			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: fromUserID, ToNick: contract.Boosters[fromUserID].Nick, Serial: xid.New().String()})
+			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: fromUserID, ToNick: contract.Boosters[fromUserID].Nick, Serial: xid.New().String(), Boost: false})
 			contract.mutex.Unlock()
 			reorderBoosters(contract)
 		}

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -19,6 +19,10 @@ func getTokensReceivedFromLog(contract *Contract, userID string) int {
 	for _, logEntry := range contract.TokenLog {
 		if logEntry.ToUserID == userID {
 			tokensReceived += logEntry.Quantity
+			if logEntry.FromUserID == logEntry.ToUserID && logEntry.Boost {
+				// Banker boosted tokens are not counted as received
+				tokensReceived -= logEntry.Quantity
+			}
 		}
 	}
 	return tokensReceived

--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -79,6 +79,7 @@ type TokenUnitLog struct {
 	ToUserID   string    // Who received the token
 	ToNick     string    // Who received the token
 	Serial     string    // Serial number of the token
+	Boost      bool      // Whether the token part of a boost
 }
 
 // EggEvent is a raw event data for Egg Inc


### PR DESCRIPTION
Adds a text outline effect to the banner text by rendering the text at multiple offset positions with a black outline color. This creates a more visually appealing and readable text on the banner.

feat(state_banker): Update boost contract state when boosting

Updates the boost contract state when a user is boosting, including setting the end time and duration of the boost, and updating the boost position in the contract.

feat(boost_button_reactions): Add boost flag to token log entries

Adds a `Boost` flag to the token log entries to indicate whether the tokens were sent as part of a boost or not. This provides more context and information about the token transactions.