### PR TITLE
feat(boost): add tokens received and sent calculation

### DIFF
--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -80,7 +80,11 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 		var logs []string
 		for _, line := range contract.TokenLog {
-			logs = append(logs, fmt.Sprintf("`%v %s %d-> %s`", line.Time.Sub(contract.StartTime).Round(time.Second), line.FromNick, line.Quantity, line.ToNick))
+			boostStr := ""
+			if line.Boost {
+				boostStr = " 🚀"
+			}
+			logs = append(logs, fmt.Sprintf("`%v %s %d->%s %s`", line.Time.Sub(contract.StartTime).Round(time.Second), line.FromNick, line.Quantity, boostStr, line.ToNick))
 		}
 
 		// Trin logs to the last 30 lines

--- a/src/boost/state_crt.go
+++ b/src/boost/state_crt.go
@@ -287,6 +287,11 @@ func drawSpeedrunCRT(contract *Contract) string {
 		}
 
 	}
+	contract.Boosters[contract.Banker.CurrentBanker].TokensReceived = getTokensReceivedFromLog(contract, contract.Boosters[contract.Banker.CurrentBanker].UserID) - getTokensSentFromLog(contract, contract.Boosters[contract.Banker.CurrentBanker].UserID)
+	if contract.Boosters[contract.Banker.CurrentBanker].BoostState == BoostStateBoosted {
+		contract.Boosters[contract.Banker.CurrentBanker].TokensReceived -= contract.Boosters[contract.Banker.CurrentBanker].TokensWanted
+	}
+
 	fmt.Fprintf(&builder, "\n**Send %s to %s** [%d]\n", contract.TokenStr, contract.Boosters[contract.Banker.CurrentBanker].Mention, contract.Boosters[contract.Banker.CurrentBanker].TokensReceived)
 
 	return builder.String()


### PR DESCRIPTION
Adds the calculation of tokens received and sent for the current
banker in the state_crt.go file. This ensures that the tokens
received value is accurate, taking into account any boosting
that has occurred.

feat(boost): add boost indicator to token logs

Adds a boost indicator (🚀) to the token logs in the boost_menu.go
file, to visually indicate when a boost has occurred. This provides
more context to the user when viewing the token transaction history.