### PR TITLE
feat: Add token count display for large values

### DIFF
--- a/src/bottools/tokens.go
+++ b/src/bottools/tokens.go
@@ -90,6 +90,9 @@ func CalculateTcountTtime(tokenValue float64, tval float64, valueLog []FutureTok
 				if i < len(valueLog) { // Ensure index is within bounds
 					ttime = fmt.Sprintf("~ <t:%d:t>", valueLog[i].Time.Unix())
 				}
+				if count >= 99 {
+					tcount = "≥99"
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Adds a special display for token counts greater than or equal to 99.
This provides a more concise representation for high token usage.