### PR TITLE
feat: Add alternate booster option to token button reaction

### DIFF
--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -32,7 +32,9 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	switch values[0] {
+	cmd := strings.Split(values[0], ":")
+
+	switch cmd[0] {
 	case "tools":
 		var outputStrBuilder strings.Builder
 		outputStrBuilder.WriteString("## Boost Tools\n")
@@ -135,5 +137,20 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		})
 		contract.EstimateUpdateTime = time.Now()
 		go updateEstimatedTime(s, i.ChannelID, contract, false)
+	case "prev":
+		prevUser := cmd[1]
+		_, redraw := buttonReactionToken(s, i.GuildID, i.ChannelID, contract, i.Member.User.ID, 1, prevUser)
+		if redraw {
+			refreshBoostListMessage(s, contract)
+		}
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("Token sent to %s", contract.Boosters[prevUser].Nick),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+
 	}
 }

--- a/src/boost/boost_reactions.go
+++ b/src/boost/boost_reactions.go
@@ -201,7 +201,7 @@ func ReactionAdd(s *discordgo.Session, r *discordgo.MessageReaction) string {
 		}
 
 		if strings.ToLower(r.Emoji.Name) == tokenReactionStr {
-			_, redraw = buttonReactionToken(s, r.GuildID, r.ChannelID, contract, userID, 1)
+			_, redraw = buttonReactionToken(s, r.GuildID, r.ChannelID, contract, userID, 1, "")
 		}
 	} else {
 		keepReaction = false

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -601,7 +601,7 @@ func speedrunReactions(s *discordgo.Session, r *discordgo.MessageReaction, contr
 		}
 	}
 	if strings.ToLower(r.Emoji.Name) == tokenReactionStr {
-		_, redraw = buttonReactionToken(s, r.GuildID, r.ChannelID, contract, userID, 1)
+		_, redraw = buttonReactionToken(s, r.GuildID, r.ChannelID, contract, userID, 1, "")
 	}
 
 	if contract.State == ContractStateBanker {


### PR DESCRIPTION
The changes in this commit add the ability to specify an alternate booster when calling the `buttonReactionToken` function. This allows the function to use a different booster than the one currently in the `BoostPosition` of the contract.

The changes include:

- Updating the `buttonReactionToken` function signature to accept an additional `alternateBooster` parameter.
- Checking if the `alternateBooster` parameter is not empty, and if so, using the booster associated with that key in the contract's `Boosters` map.
- Adding a new select menu option in the boost menu to allow users to send a token to the previous booster, if the contract is in the `ContractStateBanker` or `ContractStateFastrun` state.

These changes provide more flexibility in how tokens are distributed to boosters, allowing for scenarios where the current booster may not be the intended recipient.