### PR TITLE
feat: add next booster token button

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -481,12 +481,21 @@ func getContractReactionsComponents(contract *Contract) []discordgo.MessageCompo
 	if contract.State == ContractStateBanker || contract.State == ContractStateFastrun {
 		if contract.BoostPosition > 0 {
 			menuOptions = append(menuOptions, discordgo.SelectMenuOption{
-				Label:       fmt.Sprintf("Sent %s a token", contract.Boosters[contract.Order[contract.BoostPosition-1]].Nick),
+				Label:       fmt.Sprintf("Send %s a token", contract.Boosters[contract.Order[contract.BoostPosition-1]].Nick),
 				Description: "Previous booster wants another token.",
 				Value:       fmt.Sprintf("prev:%s", contract.Order[contract.BoostPosition-1]),
 				Emoji:       ei.GetBotComponentEmoji("token"),
 			})
 		}
+		if contract.State == ContractStateFastrun && contract.BoostPosition < len(contract.Order)-1 {
+			menuOptions = append(menuOptions, discordgo.SelectMenuOption{
+				Label:       fmt.Sprintf("Send %s a token", contract.Boosters[contract.Order[contract.BoostPosition+1]].Nick),
+				Description: fmt.Sprintf("Waiting on %s 🚀.", contract.Boosters[contract.Order[contract.BoostPosition]].Nick),
+				Value:       fmt.Sprintf("next:%s", contract.Order[contract.BoostPosition+1]),
+				Emoji:       ei.GetBotComponentEmoji("token"),
+			})
+		}
+
 	}
 
 	// Get list of at most 3 boosters, previous 2 and next 1

--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -150,7 +150,19 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 				Flags:   discordgo.MessageFlagsEphemeral,
 			},
 		})
-		return
+	case "next":
+		nextUser := cmd[1]
+		_, redraw := buttonReactionToken(s, i.GuildID, i.ChannelID, contract, i.Member.User.ID, 1, nextUser)
+		if redraw {
+			refreshBoostListMessage(s, contract)
+		}
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("Token sent to %s", contract.Boosters[nextUser].Nick),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
 
 	}
 }


### PR DESCRIPTION
This change adds a new button to the boost menu that allows the user to send a token to the next booster in the queue. This is particularly useful in the `ContractStateFastrun` where the next booster is waiting for their turn.

The changes include:

- Adding a new case statement in the `boost_menu.go` file to handle the "next" button click, which calls the `buttonReactionToken` function and refreshes the boost list message.
- Appending a new select menu option in the `boost_button_reactions.go` file to display the "Send [next booster] a token" option, with a description indicating the current booster is waiting.