### PR TITLE
feat(boost): Update boost menu placeholder text

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -551,7 +551,7 @@ func getContractReactionsComponents(contract *Contract) []discordgo.MessageCompo
 		Components: []discordgo.MessageComponent{
 			discordgo.SelectMenu{
 				CustomID:    "menu#" + contract.ContractHash,
-				Placeholder: "Additional Options",
+				Placeholder: "Boost Menu",
 				MinValues:   &minValues,
 				MaxValues:   1,
 				Options:     menuOptions,


### PR DESCRIPTION
The changes update the placeholder text for the boost menu select
menu component from "Additional Options" to "Boost Menu". This
provides a more descriptive and user-friendly label for the menu.