### PR TITLE
feat(boost): Add token send option for next booster

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -488,12 +488,15 @@ func getContractReactionsComponents(contract *Contract) []discordgo.MessageCompo
 			})
 		}
 		if contract.State == ContractStateFastrun && contract.BoostPosition < len(contract.Order)-1 {
-			menuOptions = append(menuOptions, discordgo.SelectMenuOption{
-				Label:       fmt.Sprintf("Send %s a token", contract.Boosters[contract.Order[contract.BoostPosition+1]].Nick),
-				Description: fmt.Sprintf("Waiting on %s 🚀.", contract.Boosters[contract.Order[contract.BoostPosition]].Nick),
-				Value:       fmt.Sprintf("next:%s", contract.Order[contract.BoostPosition+1]),
-				Emoji:       ei.GetBotComponentEmoji("token"),
-			})
+			b := contract.Boosters[contract.Order[contract.BoostPosition]]
+			if b.TokensWanted >= b.TokensReceived {
+				menuOptions = append(menuOptions, discordgo.SelectMenuOption{
+					Label:       fmt.Sprintf("Send %s a token", contract.Boosters[contract.Order[contract.BoostPosition+1]].Nick),
+					Description: fmt.Sprintf("Waiting on %s 🚀.", b.Nick),
+					Value:       fmt.Sprintf("next:%s", contract.Order[contract.BoostPosition+1]),
+					Emoji:       ei.GetBotComponentEmoji("token"),
+				})
+			}
 		}
 
 	}


### PR DESCRIPTION
Adds a new select menu option to send a token to the next booster in the
contract's boost order, but only if the current booster has not yet
received all the tokens they requested.