### PR TITLE
feat(boost): add token request flag and token request UI

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -167,6 +167,7 @@ type Booster struct {
 	TokensReceived         int           // indicate number of boost tokens
 	TokensWanted           int           // indicate number of boost tokens
 	TokenValue             float64       // Current Token Value
+	TokenRequestFlag       bool          // Flag to indicate if the token request is active
 	StartTime              time.Time     // Time Farmer started boost turn
 	EndTime                time.Time     // Time Farmer ended boost turn
 	Duration               time.Duration // Duration of boost

--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -40,9 +40,10 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		outputStrBuilder.WriteString("## Boost Tools\n")
 		outputStrBuilder.WriteString(fmt.Sprintf("> **Boost Bot:** %s %s %s\n", bottools.GetFormattedCommand("stones"), bottools.GetFormattedCommand("calc-contract-tval"), bottools.GetFormattedCommand("coop-tval")))
 		outputStrBuilder.WriteString("> **Wonky:** </auditcoop:1231383614701174814> </optimizestones:1235003878886342707> </srtracker:1158969351702069328>\n")
-		outputStrBuilder.WriteString(fmt.Sprintf("> **Web:** \n> * [%s](%s)\n> * [%s](%s)\n",
-			"Staabmia Stone Calc", "https://srsandbox-staabmia.netlify.app/stone-calc",
-			"Kaylier Coop Laying Assistant", "https://ei-coop-assistant.netlify.app/laying-set"))
+		outputStrBuilder.WriteString("> **Web:** \n")
+		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Staabmia Stone Calc", "https://srsandbox-staabmia.netlify.app/stone-calc"))
+		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Kaylier Coop Laying Assistant", "https://ei-coop-assistant.netlify.app/laying-set"))
+		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Token Farmer", "http://t-farmer.gigalixirapp.com/"))
 		outputStr := outputStrBuilder.String()
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -137,16 +138,30 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		})
 		contract.EstimateUpdateTime = time.Now()
 		go updateEstimatedTime(s, i.ChannelID, contract, false)
-	case "prev":
-		prevUser := cmd[1]
-		_, redraw := buttonReactionToken(s, i.GuildID, i.ChannelID, contract, i.Member.User.ID, 1, prevUser)
+	case "want":
+		message := "**%s** wants at least 1 more token."
+		contract.Boosters[i.Member.User.ID].TokenRequestFlag = !contract.Boosters[i.Member.User.ID].TokenRequestFlag
+		if !contract.Boosters[i.Member.User.ID].TokenRequestFlag {
+			message = "**%s** now has the tokens they need."
+		}
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf(message, contract.Boosters[i.Member.User.ID].Nick),
+				//Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		refreshBoostListMessage(s, contract)
+	case "send":
+		wantUser := cmd[1]
+		_, redraw := buttonReactionToken(s, i.GuildID, i.ChannelID, contract, i.Member.User.ID, 1, wantUser)
 		if redraw {
 			refreshBoostListMessage(s, contract)
 		}
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
-				Content: fmt.Sprintf("Token sent to %s", contract.Boosters[prevUser].Nick),
+				Content: fmt.Sprintf("Token sent to %s", contract.Boosters[wantUser].Nick),
 				Flags:   discordgo.MessageFlagsEphemeral,
 			},
 		})


### PR DESCRIPTION
The changes in this commit add a new `TokenRequestFlag` field to the `Booster` struct in the `boost` package. This flag is used to indicate whether a booster has requested a token or not.

Additionally, the `boost_menu.go` file has been updated to include a new "Token Farmer" link in the boost tools section, and the `boost_button_reactions.go` file has been updated to handle the new token request functionality.

The key changes are:

1. Added a new `TokenRequestFlag` field to the `Booster` struct in `boost.go`.
2. Updated the `boost_menu.go` file to include a new "Token Farmer" link in the boost tools section.
3. Updated the `boost_button_reactions.go` file to handle the new token request functionality, including adding a new select menu option to request a token and a new case to handle the "want" and "send" actions.