### PR TITLE
feat(boost): Add token ask order and playstyle options

### DIFF
--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -44,6 +44,7 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Staabmia Stone Calc", "https://srsandbox-staabmia.netlify.app/stone-calc"))
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Kaylier Coop Laying Assistant", "https://ei-coop-assistant.netlify.app/laying-set"))
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Token Farmer", "http://t-farmer.gigalixirapp.com/"))
+		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "TTokification: Android App for Speedrunners!", "https://github.com/ItsJustSomeDude/tokification-android/releases"))
 		outputStr := outputStrBuilder.String()
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,


### PR DESCRIPTION
This commit introduces two major changes to the boost contract system:

1. Adds a new "Token Ask" order option, where boosters who ask for fewer tokens will boost earlier.
2. Adds new playstyle options, including "Chill", "ACO Cooperative", "Fastrun", and "Leaderboard", which allow players to customize the contract experience.

The changes were made to provide more flexibility and customization options for contract participants, allowing them to choose the boost order and playstyle that best suits their preferences and strategies.