### PR TITLE
feat(boost): add new playstyle options and token ask order

### DIFF
--- a/src/events/launch_slashcmd.go
+++ b/src/events/launch_slashcmd.go
@@ -473,6 +473,9 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 				}
 			}
 		}
+		components = append(components, &discordgo.TextDisplay{
+			Content: events.String(),
+		})
 
 		components = append(components, &discordgo.TextDisplay{
 			Content: header.String() + "\n" + builder.String(),


### PR DESCRIPTION
The changes in this commit introduce new playstyle options for contracts and a new boost order option based on token ask amount.

The new playstyle options include:
- Chill: Everyone fills habs and uses correct artifacts
- ACO Cooperative: Chill + Everyone checks in on time
- Fastrun: ACO + Get TVal and CR from your coop size or act as sink
- Leaderboard: Fastrun + Get max CR

The new boost order option "Token Ask Order" sorts boosts based on the amount of tokens asked for, with those asking for less tokens boosting earlier.

These changes provide more flexibility and customization options for contract participants, allowing them to choose the playstyle that best suits their preferences and goals.