### PR TITLE
feat(boost): add contract play style option

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -52,6 +52,14 @@ var contractStateNames = []string{
 	"ContractStateBanker",
 }
 
+var contractPlaystyleNames = []string{
+	"Unset",
+	"Chill",
+	"ACO Cooperative",
+	"Fastrun",
+	"Leaderboard",
+}
+
 // Constnts for the contract
 const (
 	ContractOrderSignup    = 0 // Signup order
@@ -61,6 +69,7 @@ const (
 	ContractOrderTimeBased = 4 // Time based order
 	ContractOrderELR       = 5 // ELR based order
 	ContractOrderTVal      = 6 // Token Value based order
+	ContractOrderTokenAsk  = 7 // Token Ask order, less tokens boosts earlier
 
 	ContractStateSignup    = 0 // Contract is in signup phase
 	ContractStateFastrun   = 1 // Contract in Boosting as fastrun
@@ -98,6 +107,12 @@ const (
 	ContractStyleFastrunBanker     = ContractFlagBanker
 	ContractStyleSpeedrunBoostList = ContractFlagCrt | ContractFlagFastrun
 	ContractStyleSpeedrunBanker    = ContractFlagCrt | ContractFlagBanker
+
+	ContractPlaystyleUnset          = 0 // Unset
+	ContractPlaystyleChill          = 1 // Chill
+	ContractPlaystyleACOCooperative = 2 // ACO Cooperative
+	ContractPlaystyleFastrun        = 3 // Fastrun
+	ContractPlaystyleLeaderboard    = 4 // Leaderboard
 )
 
 const defaultFamerTokens = 6
@@ -242,6 +257,8 @@ type Contract struct {
 	Ultra               bool
 	UltraCount          int
 	Style               int64 // Mask for the Contract Style
+	PlayStyle           int   // Playstyle of the contract
+	NewToPlayStyle      bool  // Someone in the contract is new to this playstyle
 	LengthInSeconds     int
 	BoostOrder          int // How the contract is sorted
 	BoostVoting         int
@@ -417,6 +434,8 @@ func getBoostOrderString(contract *Contract) string {
 		return fmt.Sprintf("Egg Lay Rate order (%s)", bottools.GetFormattedCommand("artifact"))
 	case ContractOrderTVal:
 		return "Token Value order"
+	case ContractOrderTokenAsk:
+		return "Token Ask order."
 	}
 	return "Unknown"
 }
@@ -1820,6 +1839,7 @@ func reorderBoosters(contract *Contract) {
 			name     string
 			position int
 			val      float64
+			tokenAsk int
 		}
 		var orderedNames []string
 		var lastOrderNames []string
@@ -1850,6 +1870,7 @@ func reorderBoosters(contract *Contract) {
 					name:     el,
 					position: pos,
 					val:      contract.Boosters[el].TokenValue,
+					tokenAsk: contract.Boosters[el].TokensWanted,
 				})
 			}
 		}
@@ -1866,6 +1887,10 @@ func reorderBoosters(contract *Contract) {
 			} else if tvalPairs[j].position == SinkBoostLast {
 				return true
 			}
+
+			//if tvalPairs[i].tokenWant != tvalPairs[j].tokenWant {
+			//	return tvalPairs[i].tokenWant > tvalPairs[j].tokenWant
+			//}
 
 			return tvalPairs[i].val > tvalPairs[j].val
 		})

--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -497,7 +497,16 @@ func getContractReactionsComponents(contract *Contract) []discordgo.MessageCompo
 				Value: "want:",
 				Emoji: ei.GetBotComponentEmoji("token"),
 			})
-
+			/*
+				if contract.AltIcons != nil && len(contract.AltIcons) > 0 {
+					menuOptions = append(menuOptions, discordgo.SelectMenuOption{
+						Label:       "Request a token from an alternate",
+						Description: "Select an alternate to request a token from.",
+						Value:       "want-alt",
+						Emoji:       ei.GetBotComponentEmoji("token"),
+					})
+				}
+			*/
 		} else {
 			menuOptions = append(menuOptions, discordgo.SelectMenuOption{
 				Label:       "Request a token",

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -69,7 +69,9 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 
 	var bannerItem discordgo.MediaGalleryItem
 
-	bannerItem.Media.URL = fmt.Sprintf("%sb-%s.png", config.BannerURL, contract.ContractID)
+	styleArray := []string{"", "c", "a", "f", "l"}
+
+	bannerItem.Media.URL = fmt.Sprintf("%sb%s-%s.png", config.BannerURL, styleArray[contract.PlayStyle], contract.ContractID)
 	components = append(components, &discordgo.MediaGallery{
 		Items: []discordgo.MediaGalleryItem{
 			bannerItem,

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -93,6 +93,40 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 		contract.Style &^= ContractFlagSelfRuns
 	}
 
+	playstyleOptions := []discordgo.SelectMenuOption{}
+
+	if !contract.Speedrun {
+		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
+			Label:       "Chill play style",
+			Description: "Everyone fills habs and uses correct artifacts",
+			Value:       "chill",
+			Default:     (contract.PlayStyle == ContractPlaystyleChill),
+			Emoji:       ei.GetBotComponentEmoji("chill"),
+		})
+		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
+			Label:       "ACO Cooperative play style",
+			Description: "Chill + Everyone checks in on time",
+			Value:       "aco",
+			Default:     (contract.PlayStyle == ContractPlaystyleACOCooperative),
+			Emoji:       ei.GetBotComponentEmoji("aco"),
+		})
+		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
+			Label:       "Fastrun",
+			Description: "ACO + Get TVal and CR from your coop size or act as sink",
+			Value:       "fastrun",
+			Default:     (contract.PlayStyle == ContractPlaystyleFastrun),
+			Emoji:       ei.GetBotComponentEmoji("fastrun"),
+		})
+	} else {
+		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
+			Label:       "Leaderboard",
+			Description: "Fastrun + Get max CR",
+			Value:       "leaderboard",
+			Default:     (contract.PlayStyle == ContractPlaystyleLeaderboard),
+			Emoji:       ei.GetBotComponentEmoji("leaderboard"),
+		})
+	}
+
 	return builder.String(), []discordgo.MessageComponent{
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
@@ -131,15 +165,6 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 							Emoji:       ei.GetBotComponentEmoji("signup"),
 							Default:     contract.BoostOrder == ContractOrderSignup,
 						},
-						/*
-							{
-								Label:       "Fair Order",
-								Description: "Boost order is based order history in last 5 contracts",
-								Value:       "fair",
-								Emoji:       ei.GetBotComponentEmoji("fair"),
-								Default:     contract.BoostOrder == ContractOrderFair,
-							},
-						*/
 						{
 							Label:       "Token Value Order",
 							Description: "Highest token value boosts earlier",
@@ -154,6 +179,15 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 							Emoji:       ei.GetBotComponentEmoji("elr"),
 							Default:     contract.BoostOrder == ContractOrderELR,
 						},
+						/*
+							{
+								Label:       "Token Ask Order",
+								Description: "Those asking for less tokens boost earlier",
+								Value:       "ask",
+								Emoji:       ei.GetBotComponentEmoji("ask"),
+								Default:     contract.BoostOrder == ContractOrderTokenAsk,
+							},
+						*/
 						{
 							Label:       "Random Order",
 							Description: "Boost order is random",
@@ -169,6 +203,17 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 							Default:     contract.BoostOrder == ContractOrderReverse,
 						},
 					},
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    "cs_#play#" + id,
+					Placeholder: "Choose your play style",
+					MinValues:   &minValues,
+					MaxValues:   1,
+					Options:     playstyleOptions,
 				},
 			},
 		},

--- a/src/boost/thread.go
+++ b/src/boost/thread.go
@@ -157,8 +157,12 @@ func generateThreadName(c *Contract) string {
 
 	if strings.Contains(threadName, "$COUNT") || strings.Contains(threadName, "$C") {
 		var statusStr string
+		playStyleStr := ""
+		if c.PlayStyle != ContractPlaystyleUnset && c.PlayStyle < len(contractPlaystyleNames) {
+			playStyleStr = fmt.Sprintf("%s ", contractPlaystyleNames[c.PlayStyle])
+		}
 		if len(c.Order) != c.CoopSize {
-			statusStr = fmt.Sprintf("(%d/%d)", len(c.Order), c.CoopSize)
+			statusStr = fmt.Sprintf("(%s%d/%d)", playStyleStr, len(c.Order), c.CoopSize)
 		} else {
 			statusStr = "(FULL)"
 		}


### PR DESCRIPTION
This commit adds a new "play-style" option to the `/contract` command, allowing users to select the desired play style for the contract. The available options are:

- Chill
- ACO Cooperative (default)
- Fastrun
- Leaderboard

The contract's play style is then used to generate the appropriate banner image URL and display the play style information in the contract thread name.

This change provides more flexibility for users to customize their contract experience based on their preferences.