### PR TITLE
feat(boost): add boost trigger time to contract

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -604,6 +604,7 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		}
 	}
 
+	originalPlayStyle := contract.PlayStyle
 	// Handle the play style flair
 	if cmd == "play" {
 		values := data.Values
@@ -633,6 +634,11 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		contract.PlayStyle = ContractPlaystyleFastrun
 		redrawSignup = true
 		redrawSettings = true
+	}
+
+	if originalPlayStyle != contract.PlayStyle {
+		// Need to rename the thread if it exists
+		UpdateThreadName(s, contract)
 	}
 
 	// With the changed settings values, we need to redraw the current Interaction message

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -43,6 +43,7 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 			// Going to be boosting the sink so make sure they
 			contract.Boosters[contract.Order[contract.BoostPosition]].BoostState = BoostStateUnboosted
 			contract.Boosters[cUserID].StartTime = contract.StartTime
+			contract.Boosters[cUserID].BoostTriggerTime = time.Now()
 			contract.Boosters[cUserID].EndTime = time.Now()
 			contract.Boosters[cUserID].Duration = time.Since(contract.Boosters[cUserID].StartTime)
 			contract.Boosters[contract.Order[contract.BoostPosition]].StartTime = time.Time{}


### PR DESCRIPTION
The changes in this commit add the boost trigger time to the contract. This is
necessary to properly track the duration of the boost and ensure that the
boost is applied correctly. The changes also include a check to see if the
play style has changed, and if so, update the thread name accordingly.