### PR TITLE
feat(events): improve display of launch command response

### DIFF
--- a/src/events/launch_slashcmd.go
+++ b/src/events/launch_slashcmd.go
@@ -473,9 +473,11 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 				}
 			}
 		}
-		components = append(components, &discordgo.TextDisplay{
-			Content: events.String(),
-		})
+		if events.Len() > 0 {
+			components = append(components, &discordgo.TextDisplay{
+				Content: events.String(),
+			})
+		}
 
 		components = append(components, &discordgo.TextDisplay{
 			Content: header.String() + "\n" + builder.String(),
@@ -548,9 +550,13 @@ func HandleLaunchHelper(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		Content: instr.String(),
 	})
 
-	_, _ = s.FollowupMessageCreate(i.Interaction, true,
+	_, err := s.FollowupMessageCreate(i.Interaction, true,
 		&discordgo.WebhookParams{
 			Flags:      discordgo.MessageFlagsIsComponentsV2,
 			Components: components,
 		})
+	if err != nil {
+		fmt.Println("Error sending followup message:", err)
+		return
+	}
 }


### PR DESCRIPTION
The changes made in this commit improve the display of the response to the
launch slash command. Specifically:

- The events text is only included in the response if there are any events to
  display.
- The error handling for sending the followup message has been improved to
  print any errors that occur.

These changes ensure a cleaner and more informative response to the launch
command, and provide better error handling for the command execution.