### PR TITLE
feat: Fix typo in Tokification app name

### DIFF
--- a/src/boost/boost_menu.go
+++ b/src/boost/boost_menu.go
@@ -44,7 +44,7 @@ func HandleMenuReactions(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Staabmia Stone Calc", "https://srsandbox-staabmia.netlify.app/stone-calc"))
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Kaylier Coop Laying Assistant", "https://ei-coop-assistant.netlify.app/laying-set"))
 		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Token Farmer", "http://t-farmer.gigalixirapp.com/"))
-		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "TTokification: Android App for Speedrunners!", "https://github.com/ItsJustSomeDude/tokification-android/releases"))
+		outputStrBuilder.WriteString(fmt.Sprintf("> * [%s](%s)\n", "Tokification: Android App for Speedrunners!", "https://github.com/ItsJustSomeDude/tokification-android/releases"))
 		outputStr := outputStrBuilder.String()
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,


### PR DESCRIPTION
The changes fix a typo in the name of the Tokification Android app. The
name is corrected from "TTokification" to "Tokification" to match the
actual app name.