### PR TITLE
feat(boost): Add token value display and separator in waiting state

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -538,7 +538,14 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 		}
 
 	case ContractStateWaiting:
-		guidanceStr.WriteString("\n")
+		coopTvalStr := calculateTokenValueCoopLog(contract, contract.EstimatedDuration, targetTval)
+		components = append(components, &discordgo.TextDisplay{
+			Content: coopTvalStr,
+		})
+		components = append(components, &discordgo.Separator{
+			Divider: &divider,
+			Spacing: &spacing,
+		})
 		guidanceStr.WriteString("> Waiting for other(s) to join...\n")
 		guidanceStr.WriteString("> Use pinned message or add 🧑‍🌾 reaction to join this list and set boost " + tokenStr + " wanted.\n")
 		totalContentLength := guidanceStr.Len()


### PR DESCRIPTION
Adds a new token value display and a separator to the guidance message
when the contract is in the waiting state. This provides more
informative guidance to users about the current token value and
encourages them to join the boost by reacting with the 🧑‍🌾 emoji.