### PR TITLE
feat(help): Add new subcommands for changing contract start time

### DIFF
--- a/src/boost/help.go
+++ b/src/boost/help.go
@@ -68,10 +68,12 @@ func GetHelp(s *discordgo.Session, guildID string, channelID string, userID stri
 			// Speedrun info
 			speedRunStr := fmt.Sprintf(`
 			> * Use %s to bring up the contract settings.
-			> * Use %s to set the planned start time for the contract.
+			> * Use %s or %s to set the planned start time for the contract.
 			`,
 				bottools.GetFormattedCommand("contract-settings"),
-				bottools.GetFormattedCommand("change-planned-start"))
+				bottools.GetFormattedCommand("change-start offset"),
+				bottools.GetFormattedCommand("change-start timestamp"),
+			)
 
 			field = append(field, &discordgo.MessageEmbedField{
 				Name:   "Basic Contract Info",

--- a/src/bottools/app_cmdlinks.go
+++ b/src/bottools/app_cmdlinks.go
@@ -10,6 +10,14 @@ var commandMap = make(map[string]string)
 func UpdateCommandMap(commands []*discordgo.ApplicationCommand) {
 	for _, cmd := range commands {
 		commandMap[cmd.Name] = cmd.ID
+		// Handle subcommands
+		if len(cmd.Options) > 0 {
+			for _, option := range cmd.Options {
+				if option.Type == discordgo.ApplicationCommandOptionSubCommand {
+					commandMap[cmd.Name+" "+option.Name] = cmd.ID
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The changes in this commit add support for two new subcommands to the "change-planned-start" command: "change-start offset" and "change-start timestamp". This allows users to set the planned start time for a contract using either a time offset or a specific timestamp.

The commit also updates the help message to reflect these new subcommands, making it clearer for users how to set the planned start time for a contract.