### PR TITLE
feat(boost): Add commands to change planned start time

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 )
@@ -14,13 +15,13 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 	minValues := 1
 	minZeroValues := 0
 
-	// is this channelID a thread
-
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "Contract created in <#%s>\n", channelID)
 	builder.WriteString("Use the Contract button if you have to recycle it.\n")
 	builder.WriteString("**Use the menus to set your contract style. These will work until the contract is started.**\n")
-	builder.WriteString("If this contract isn't an immediate start use `/change-planned-start` to add the time to the sign-up message.\n")
+	fmt.Fprintf(&builder, "If this contract isn't an immediate start use %s or %s to add the time to the sign-up message.\n",
+		bottools.GetFormattedCommand("change-start offset"),
+		bottools.GetFormattedCommand("change-start timestamp"))
 	if thread {
 		builder.WriteString("React with 🌊 on the boost list to automaticaly update the thread name (`/rename-thread`).\n")
 	} else {


### PR DESCRIPTION
This commit adds two new commands to the boost bot:

1. `change-start offset`: Allows users to set a planned start time for the
   contract by specifying an offset from the current time (e.g. "+2h").
2. `change-start timestamp`: Allows users to set a planned start time for the
   contract by specifying a timestamp (e.g. "2023-04-01 12:00:00").

These commands are added to the sign-up message to provide users with more
flexibility in scheduling their contracts.