### PR TITLE
feat(contract): Add thread style icons to contract IDs

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -222,9 +222,10 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 
 	// Create a new thread for this contract
 	if makeThread {
+		threadStyleIcons := []string{"", "🟦 ", "🟩 ", "🟧 ", "🟥 "}
 		// Default to 1 day timeout
 		var builder strings.Builder
-		builder.WriteString(coopID)
+		fmt.Fprintf(&builder, "%s %s", threadStyleIcons[playStyle], coopID)
 		info := ei.EggIncContractsAll[contractID]
 		if info.ID != "" {
 			fmt.Fprintf(&builder, " (0/%d)", info.MaxCoopSize)


### PR DESCRIPTION
Adds thread style icons to the contract IDs in the contract creation
process. This provides a visual cue for the player to quickly identify
the contract type (e.g. Enlightenment, Tachyon, etc.) when viewing the
contract list.