### PR TITLE
feat(boost): change contract playstyle logic

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -96,7 +96,7 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 
 	playstyleOptions := []discordgo.SelectMenuOption{}
 
-	if !contract.Speedrun {
+	if (contract.Style & ContractFlagCrt) == 0 {
 		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
 			Label:       "Chill play style",
 			Description: "Everyone fills habs and uses correct artifacts",

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -638,12 +638,11 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 	redrawSettings := false
 
 	// A contract that's a CRT is by definition al leaderboard play style
-	if contract.Speedrun {
+	if (contract.Style & ContractFlagCrt) != 0 {
 		contract.PlayStyle = ContractPlaystyleLeaderboard
 		redrawSignup = true
 		redrawSettings = true
-	}
-	if !contract.Speedrun && contract.PlayStyle == ContractPlaystyleLeaderboard {
+	} else if (contract.Style&ContractFlagCrt) == 0 && contract.PlayStyle == ContractPlaystyleLeaderboard {
 		contract.PlayStyle = ContractPlaystyleFastrun
 		redrawSignup = true
 		redrawSettings = true


### PR DESCRIPTION
The changes in this commit update the logic for determining the contract playstyle based on the contract's style flags. The main changes are:

- If the contract has the CRT flag set, the playstyle is set to Leaderboard, regardless of the previous playstyle.
- If the contract does not have the CRT flag set and the previous playstyle was Leaderboard, the playstyle is set to Fastrun.
- The `Speedrun` field is replaced with a more generic `Style` field that uses bit flags to represent the contract's characteristics.

These changes ensure that the contract playstyle is correctly determined based on the contract's style, simplifying the logic and making it more flexible for future contract types.