### PR TITLE
feat: Change "ACO Cooperative" to "ACO Coop"

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -55,7 +55,7 @@ var contractStateNames = []string{
 var contractPlaystyleNames = []string{
 	"Unset",
 	"Chill",
-	"ACO Cooperative",
+	"ACO Coop",
 	"Fastrun",
 	"Leaderboard",
 }


### PR DESCRIPTION
The "ACO Cooperative" playtstyle name is changed to "ACO Coop" to
make it more concise and easier to read. This change is part of a
larger effort to improve the readability and consistency of the
playtstyle names.