### PR TITLE
feat(teamwork): Increase max farm capacity for 3 slot artifacts

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -630,7 +630,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 						// Assuming being replaced with a 3 slot artifact
 						p := c.GetProductionParams()
 						farmCapacity := p.GetFarmCapacity() * eiContract.Grade[grade].ModifierHabCap
-						maxFarm := 14125000000.0 * eiContract.Grade[grade].ModifierHabCap
+						maxFarm := 14175000000.0 * eiContract.Grade[grade].ModifierHabCap
 						swapArtifactName := "artifact"
 						if maxFarm != farmCapacity {
 							swapArtifactName = "gusset"


### PR DESCRIPTION
Increase the maximum farm capacity for 3 slot artifacts from 14,125,000,000
to 14,175,000,000. This change is necessary to accommodate the increased
production capabilities of the new 3 slot artifacts.