### PR TITLE
feat(teamwork): Increase farm capacity based on colleggtible habitat

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -628,9 +628,10 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 							}
 						}
 						// Assuming being replaced with a 3 slot artifact
+						_, _, colleggtibleHab := ei.GetColleggtibleValues()
 						p := c.GetProductionParams()
 						farmCapacity := p.GetFarmCapacity() * eiContract.Grade[grade].ModifierHabCap
-						maxFarm := 14175000000.0 * eiContract.Grade[grade].ModifierHabCap
+						maxFarm := 14175000000.0 * eiContract.Grade[grade].ModifierHabCap * colleggtibleHab
 						swapArtifactName := "artifact"
 						if maxFarm != farmCapacity {
 							swapArtifactName = "gusset"


### PR DESCRIPTION
The changes in this commit increase the farm capacity calculation based on the
colleggtible habitat value. Previously, the farm capacity was calculated using
only the contract grade modifier, but now it also takes into account the
colleggtible habitat value. This ensures that the farm capacity is more
accurately represented and reflects the impact of the colleggtible habitat.