### PR TITLE
feat(contract): strip Boost list style and set to banker style

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -639,6 +639,10 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 
 	// A contract that's a CRT is by definition al leaderboard play style
 	if (contract.Style & ContractFlagCrt) != 0 {
+		// strip the Boost list style and set it to banker style
+		contract.Style &= ^ContractFlagFastrun
+		contract.Style |= ContractFlagBanker
+
 		contract.PlayStyle = ContractPlaystyleLeaderboard
 		redrawSignup = true
 		redrawSettings = true


### PR DESCRIPTION
The changes made in this commit strip the Boost list style from the contract
and set the contract's style to banker style. This is done because a contract
that is a CRT (Continuous Running Tournament) is by definition a leaderboard
play style, and the Boost list style is not compatible with this.