### PR TITLE
feat: Add timestamp to coop data file name

### DIFF
--- a/src/ei/coop_status.go
+++ b/src/ei/coop_status.go
@@ -115,7 +115,7 @@ func GetCoopStatus(contractID string, coopID string) (*ContractCoopStatusRespons
 		eiDatas[cacheID] = &data
 
 		// Save protoData into a file
-		fileName := fmt.Sprintf("ttbb-data/%s-%s.pb", contractID, coopID)
+		fileName := fmt.Sprintf("ttbb-data/%s-%s-%s.pb", contractID, coopID, timestamp.Format("20060102150405"))
 		err = os.WriteFile(fileName, []byte(protoData), 0644)
 		if err != nil {
 			log.Print(err)


### PR DESCRIPTION
Modify the file name format for the coop data file to include a timestamp.
This will help differentiate between multiple coop data files for the same
contract and coop.