### PR TITLE
feat(config): Add DevelopmentStaff configuration

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -3,6 +3,7 @@ package boost
 import (
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -118,6 +119,10 @@ func HandleTeamworkEvalCommand(s *discordgo.Session, i *discordgo.InteractionCre
 	if opt, ok := optionMap["coop-id"]; ok {
 		coopID = strings.ToLower(opt.StringValue())
 		coopID = strings.ReplaceAll(coopID, " ", "")
+		// Only Development Staff can use a coop-id that starts with '?'
+		if !slices.Contains(config.DevelopmentStaff, userID) && strings.HasPrefix(coopID, "?") {
+			coopID = strings.TrimPrefix(coopID, "?")
+		}
 	}
 	if opt, ok := optionMap["public-reply"]; ok {
 		publicReply = !opt.BoolValue()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -45,6 +45,8 @@ var (
 	BannerOutputPath string
 	// BannerURL is the URL to the banner image.
 	BannerURL string
+	// DevelopmentStaff is a list of user IDs for development staff.
+	DevelopmentStaff []string
 
 	config *configStruct
 )
@@ -69,6 +71,7 @@ type configStruct struct {
 	BannerPath       string   `json:"BannerPath"`
 	BannerOutputPath string   `json:"BannerOutputPath"`
 	BannerURL        string   `json:"BannerURL"`
+	DevelopmentStaff []string `json:"DevelopmentStaff"`
 }
 
 // ReadConfig will load the configuration files for API tokens.
@@ -108,6 +111,7 @@ func ReadConfig(cfgFile string) error {
 	BannerPath = config.BannerPath
 	BannerOutputPath = config.BannerOutputPath
 	BannerURL = config.BannerURL
+	DevelopmentStaff = config.DevelopmentStaff
 
 	return nil
 }


### PR DESCRIPTION
This change adds a new configuration option called `DevelopmentStaff` to
the `config.go` file. This option is a list of user IDs for development 
staff. This change is necessary to implement a new feature that allows 
only development staff to use a coop-id that starts with a '?' 
character.

The changes also include updating the `configStruct` and the `ReadConfig`
function to handle the new configuration option.