### PR TITLE
feat: Ensure valid page index in teamwork pages

### DIFF
--- a/src/boost/teamwork_pages.go
+++ b/src/boost/teamwork_pages.go
@@ -168,6 +168,10 @@ func sendTeamworkPage(s *discordgo.Session, i *discordgo.InteractionCreate, newM
 		flags = 0
 	}
 
+	if cache.page < 0 || cache.page >= cache.pages {
+		cache.page = 0
+	}
+
 	key := cache.names[cache.page]
 
 	field := cache.fields[key]


### PR DESCRIPTION
Fixes an issue where the page index could be out of bounds,
causing the application to crash. This change ensures the
page index is always within the valid range of pages.