### PR TITLE
feat: Add sort rate to boost display

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -469,7 +469,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 							}
 							boostingString += fmt.Sprintf(" %s<t:%d:R>", habFull, b.EstEndOfBoost.Unix())
 						}
-						builder.WriteString(fmt.Sprintf("%s ~~%s~~  %s %s%s%s%s\n", prefix, name, contract.Boosters[element].Duration.Round(time.Second), sinkIcon, boostingString, chickenStr, server))
+						builder.WriteString(fmt.Sprintf("%s ~~%s~~  %s %s%s%s%s%s\n", prefix, name, sortRate, contract.Boosters[element].Duration.Round(time.Second), sinkIcon, boostingString, chickenStr, server))
 					}
 				}
 			}


### PR DESCRIPTION
Adds the sort rate to the boost display in the `boost_draw.go` file.
This change allows users to see the sort rate for each boost, which is
an important piece of information when deciding which boosts to use.