### PR TITLE
feat(coop-status): Add timestamp in Unix format to data timestamp

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -3,6 +3,7 @@ package boost
 import (
 	"fmt"
 	"math"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -247,6 +248,28 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 	if strings.HasPrefix(coopID, "?") {
 		coopID = strings.TrimPrefix(coopID, "?")
 		extraInfo = true
+	}
+
+	if strings.HasPrefix(coopID, "**") {
+		coopID = strings.TrimPrefix(coopID, "**")
+		// Want to get a list of the filenames within the ttbb-data directory
+		files, err := os.ReadDir("ttbb-data")
+		if err != nil {
+			return "Failed to read ttbb-data directory.", nil, ""
+		}
+		var fileNames []string
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			fileName := file.Name()
+			// Check if filename contains the coopID pattern
+			if strings.Contains(fileName, contractID+"-"+coopID+"-") {
+				fileNames = append(fileNames, fileName)
+			}
+		}
+		// Return the list of matching filenames
+		return fmt.Sprintf("Filenames:\n%s", strings.Join(fileNames, "\n")), nil, ""
 	}
 
 	coopStatus, nowTime, dataTimestampStr, err := ei.GetCoopStatus(contractID, coopID)
@@ -952,7 +975,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		fmt.Printf("Total Delta ELR Sum: %f\n", deltaELRSum)
 		builder.WriteString(fmt.Sprintf("Total Delta ELR Sum: %f\n", deltaELRSum))
 		fmt.Printf("Min Alpha: %f\n", alpha)
-		builder.WriteString(fmt.Sprintf("Alpha: %f\n", alpha))
+		builder.WriteString(fmt.Sprintf("Min Alpha: %f\n", alpha))
 	}
 
 	// Create a table of Contract Scores for this user

--- a/src/ei/coop_status.go
+++ b/src/ei/coop_status.go
@@ -67,7 +67,7 @@ func GetCoopStatus(contractID string, coopID string) (*ContractCoopStatusRespons
 
 		timestamp = fileTimestamp
 		dataTimestampStr = fmt.Sprintf("\nUsing cached data from file %s", fname)
-		dataTimestampStr += fmt.Sprintf(", timestamp: %s", fileTimestamp.Format("2006-01-02 15:04:05"))
+		dataTimestampStr += fmt.Sprintf("\n%s <t:%d:f>", fileTimestamp.Format("2006-01-02 15:04:05"), fileTimestamp.Unix())
 
 	} else if cachedData != nil && time.Now().Before(cachedData.expirationTimestamp) {
 		protoData = cachedData.protoData


### PR DESCRIPTION
The changes in this commit add the Unix timestamp to the data timestamp 
string in the `coop_status.go` file. This makes it easier to parse and 
use the timestamp information.

Additionally, in the `teamwork.go` file, a new feature is added to handle the case where the `coopID` starts with `**`. In this case, the function will search for files in the `ttbb-data` directory that match the `contractID` and `coopID` pattern, and return the list of matching filenames.