### PR TITLE
feat(teamwork): Improve contract progress display

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -356,7 +356,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		endTime = nowTime.Add(time.Duration(calcSecondsRemaining) * time.Second)
 		contractDurationSeconds = endTime.Sub(startTime).Seconds()
 		elapsedSeconds = nowTime.Sub(startTime).Seconds()
-		builder.WriteString(fmt.Sprintf("In Progress %s %s/[**%s**](%s) on target to complete <t:%d:R>\n", ei.GetBotEmojiMarkdown("contract_grade_"+ei.GetContractGradeString(grade)), contractID, coopID, fmt.Sprintf("%s/%s/%s", "https://eicoop-carpet.netlify.app", contractID, coopID), endTime.Unix()))
+		builder.WriteString(fmt.Sprintf("In Progress %s %s/[**%s**](%s) on target to complete <t:%d:R>\n", ei.GetBotEmojiMarkdown("contract_grade_"+ei.GetContractGradeString(grade)), coopStatus.GetContractIdentifier(), coopStatus.GetCoopIdentifier(), fmt.Sprintf("%s/%s/%s", "https://eicoop-carpet.netlify.app", contractID, coopID), endTime.Unix()))
 	}
 
 	UpdateContractTime(coopStatus.GetContractIdentifier(), coopStatus.GetCoopIdentifier(), startTime, contractDurationSeconds)


### PR DESCRIPTION
Refactor the contract progress display to use the contract and coop
identifiers from the `coopStatus` object instead of hardcoded values.
This ensures the information displayed is accurate and up-to-date.