### PR TITLE
feat(boost): Add toggle-contract-pings command

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ const slashPrune string = "prune"
 const slashJoin string = "join-contract"
 const slashSetEggIncName string = "seteggincname"
 const slashBump string = "bump"
+const slashToggleContractPings string = "toggle-contract-pings"
 const slashContractSettings string = "contract-settings"
 const slashHelp string = "help"
 const slashSpeedrun string = "speedrun"
@@ -303,6 +304,10 @@ var (
 			Description: "Redraw the boost list to the timeline.",
 		},
 		{
+			Name:        slashToggleContractPings,
+			Description: "Toggle Boost Bot contract pings [sticky]",
+		},
+		{
 			Name:        slashHelp,
 			Description: "Help with Boost Bot commands.",
 		},
@@ -548,6 +553,9 @@ var (
 		},
 		slashBump: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleBumpCommand(s, i)
+		},
+		slashToggleContractPings: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleToggleContractPingsCommand(s, i)
 		},
 		slashContractSettings: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleContractSettingsCommand(s, i)

--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -303,7 +303,7 @@ func buttonReactionRunChickens(s *discordgo.Session, contract *Contract, cUserID
 		}
 		go func() {
 			for _, location := range contract.Location {
-				str := fmt.Sprintf("%s **%s** is ready for chicken runs, check for incoming trucks before visiting.", location.ChannelPing, contract.Boosters[userID].Mention)
+				str := fmt.Sprintf("%s **%s** is ready for chicken runs, check for incoming trucks before visiting.", location.RoleMention, contract.Boosters[userID].Mention)
 				var data discordgo.MessageSend
 				data.Content = str
 				data.Embeds = []*discordgo.MessageEmbed{

--- a/src/boost/boost_change.go
+++ b/src/boost/boost_change.go
@@ -395,7 +395,7 @@ func HandleChangePingRoleCommand(s *discordgo.Session, i *discordgo.InteractionC
 	// No error string means we are good to go
 	if str == "" {
 		// Default to @here when there is no parameter
-		newRole := "@here"
+		//newRole := "@here"
 
 		options := i.ApplicationCommandData().Options
 		optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
@@ -403,23 +403,25 @@ func HandleChangePingRoleCommand(s *discordgo.Session, i *discordgo.InteractionC
 			optionMap[opt.Name] = opt
 		}
 
-		if opt, ok := optionMap["ping-role"]; ok {
-			role := opt.RoleValue(nil, "")
-			newRole = role.Mention()
-		}
-
-		for _, loc := range contract.Location {
-			if loc.ChannelID == i.ChannelID {
-				if loc.ChannelPing == newRole {
-					str = "Ping role already set to " + newRole
-					break
-				}
-				loc.ChannelPing = newRole
-				str = "Ping role changed to " + newRole
-				_, _ = s.ChannelMessageSend(i.ChannelID, str)
-				break
+		/*
+			if opt, ok := optionMap["ping-role"]; ok {
+				role := opt.RoleValue(nil, "")
+				newRole = role.Mention()
 			}
-		}
+
+				for _, loc := range contract.Location {
+					if loc.ChannelID == i.ChannelID {
+						if loc.ChannelPing == newRole {
+							str = "Ping role already set to " + newRole
+							break
+						}
+						loc.ChannelPing = newRole
+						str = "Ping role changed to " + newRole
+						_, _ = s.ChannelMessageSend(i.ChannelID, str)
+						break
+					}
+				}
+		*/
 	}
 
 	_, _ = s.FollowupMessageCreate(i.Interaction, true,


### PR DESCRIPTION
This commit adds a new command `/toggle-contract-pings` that allows 
users to toggle whether they receive pings for a contract they are part 
of. When enabled, the user will be added to the contract's role, and 
when disabled, the user will be removed from the role.

Additionally, this commit includes a change to the `DeleteContract` function
to also delete the contract's role when the contract is deleted.