### PR TITLE
feat(contract): add new admin choice name "TBone Alt"

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -65,6 +65,9 @@ var randomThingNames []string = []string{
 	"Banshee", "Wendigo", "Valkyrie", "Leviathan", "Behemoth", "Manticore", "Cockatrice", "Wyvern", "Pegasus", "Unicorn",
 	"Cyclops", "Medusa", "Gorgon", "Harpy", "Siren", "Dullahan", "Kelpie", "Selkie", "Roc", "Thunderbird",
 	"Quetzalcoatl", "Jormungandr", "Fenrir", "Sleipnir", "Djinn", "Ifrit", "Salamander", "Undine", "Sylph", "Gnome",
+
+	// Admin Choice Names (1 name)
+	"TBone Alt",
 }
 
 // GetSlashContractCommand returns the slash command for creating a contract


### PR DESCRIPTION
Adds a new admin choice name "TBone Alt" to the list of available
contract names. This change provides more options for admins to
choose from when creating new contracts.