### PR TITLE
feat(teamwork): Update directory for reading and writing files

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -253,7 +253,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 	if strings.HasPrefix(coopID, "**") {
 		coopID = strings.TrimPrefix(coopID, "**")
 		// Want to get a list of the filenames within the ttbb-data directory
-		files, err := os.ReadDir("ttbb-data")
+		files, err := os.ReadDir("ttbb-data/pb")
 		if err != nil {
 			return "Failed to read ttbb-data directory.", nil, ""
 		}

--- a/src/ei/coop_status.go
+++ b/src/ei/coop_status.go
@@ -50,7 +50,7 @@ func GetCoopStatus(contractID string, coopID string) (*ContractCoopStatusRespons
 	if strings.HasPrefix(coopID, "!!") {
 		basename := coopID[2:]
 		coopID = coopID[2:]
-		fname := fmt.Sprintf("ttbb-data/%s-%s.pb", contractID, basename)
+		fname := fmt.Sprintf("ttbb-data/pb/%s-%s.pb", contractID, basename)
 
 		// read the contents of filename into protoData
 		fileInfo, err := os.Stat(fname)
@@ -115,7 +115,12 @@ func GetCoopStatus(contractID string, coopID string) (*ContractCoopStatusRespons
 		eiDatas[cacheID] = &data
 
 		// Save protoData into a file
-		fileName := fmt.Sprintf("ttbb-data/%s-%s-%s.pb", contractID, coopID, timestamp.Format("20060102150405"))
+		fileName := fmt.Sprintf("ttbb-data/pb/%s-%s-%s.pb", contractID, coopID, timestamp.Format("20060102150405"))
+		// make sure the directory exists
+		if err := os.MkdirAll("ttbb-data/pb", 0755); err != nil {
+			log.Print(err)
+			return nil, timestamp, dataTimestampStr, err
+		}
 		err = os.WriteFile(fileName, []byte(protoData), 0644)
 		if err != nil {
 			log.Print(err)


### PR DESCRIPTION
- Update directory for reading files in `teamwork.go` from `"ttbb-data"` to `"ttbb-data/pb"`.
- Update directory for writing files in `coop_status.go` from `"ttbb-data"` to `"ttbb-data/pb"`.
- Create new directory `"ttbb-data/pb"` in `coop_status.go` if it doesn't already exist before writing the file.