### PR TITLE
feat: Add switch time to production schedule output

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -743,6 +743,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 						productionScheduleParamsArray = append(productionScheduleParamsArray, params)
 
 						if err == nil {
+							maxTeamwork.WriteString(fmt.Sprintf("\n%s: <t:%d:f>\n", "Switch time ", switchTimestamp))
 							maxTeamwork.WriteString(fmt.Sprintf("%s: <t:%d:f>\n", "Finish time with 1 player switch", finishTimestampWithSwitch))
 							if extraInfo {
 								siabEndtimes = append(siabEndtimes, finishTimestampWithSwitch)


### PR DESCRIPTION
Adds the switch time to the production schedule output, in addition to the
finish time with one player switch. This provides more detailed information
about the production schedule to the user.