### PR TITLE
feat: Sort contract roles alphabetically

### DIFF
--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strings"
 
@@ -84,9 +85,7 @@ func HandleAdminListRoles(s *discordgo.Session, i *discordgo.InteractionCreate) 
 			if c.ID == contractID {
 				sortedContractRoles := make([]string, 0)
 				sortedContractRoles = append(sortedContractRoles, c.TeamNames...)
-				sort.Slice(sortedContractRoles, func(i, j int) bool {
-					return sortedContractRoles[i] < sortedContractRoles[j]
-				})
+				slices.Sort(sortedContractRoles)
 				for _, role := range sortedContractRoles {
 					// if this role is in the guild roles, display it
 					name := role


### PR DESCRIPTION
Sorts the contract roles in the `boost_admin.go` file
alphabetically using the `slices.Sort()` function instead of
the `sort.Slice()` function. This makes the code more
readable and maintainable.