### PR TITLE
feat(admin): Modify slash command to remove admin permission

### DIFF
--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -44,11 +44,11 @@ func SlashAdminGetContractData(cmd string) *discordgo.ApplicationCommand {
 
 // SlashAdminListRoles is the slash to info about bot roles
 func SlashAdminListRoles(cmd string) *discordgo.ApplicationCommand {
-	var adminPermission = int64(0)
+	//var adminPermission = int64(0)
 	return &discordgo.ApplicationCommand{
-		Name:                     cmd,
-		Description:              "Display contract role usage",
-		DefaultMemberPermissions: &adminPermission,
+		Name:        cmd,
+		Description: "Display contract role usage",
+		//DefaultMemberPermissions: &adminPermission,
 		Options: []*discordgo.ApplicationCommandOption{
 			{
 				Type:         discordgo.ApplicationCommandOptionString,


### PR DESCRIPTION
The changes made in this commit are:

1. Removed the `adminPermission` variable assignment as it is no longer needed.
2. Removed the `DefaultMemberPermissions` field from the `discordgo.ApplicationCommand` struct as it is not required for the functionality of the slash command.

These changes were made to simplify the implementation of the `SlashAdminListRoles` function and remove unnecessary code.