### PR TITLE
feat: add ultra indicator to contract names

### DIFF
--- a/src/boost/boost_autocomplete.go
+++ b/src/boost/boost_autocomplete.go
@@ -14,8 +14,12 @@ func HandleContractAutoComplete(s *discordgo.Session, i *discordgo.InteractionCr
 	// User interacting with bot, is this first time ?
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
 	for _, c := range ei.EggIncContracts {
+		ultra := ""
+		if c.Ultra {
+			ultra = " -ultra"
+		}
 		choice := discordgo.ApplicationCommandOptionChoice{
-			Name:  fmt.Sprintf("%s (%s)", c.Name, c.ID),
+			Name:  fmt.Sprintf("%s (%s)%s", c.Name, c.ID, ultra),
 			Value: c.ID,
 		}
 		choices = append(choices, &choice)


### PR DESCRIPTION
The changes add an "ultra" indicator to the contract names in the
autocomplete options. This helps users quickly identify ultra
contracts when selecting a contract from the list.