### PR TITLE
feat: add ultra indicator to contract names

### DIFF
--- a/src/boost/boost_autocomplete.go
+++ b/src/boost/boost_autocomplete.go
@@ -56,8 +56,12 @@ func HandleAllContractsAutoComplete(s *discordgo.Session, i *discordgo.Interacti
 
 	if searchString == "" {
 		for _, c := range ei.EggIncContracts {
+			ultra := ""
+			if c.Ultra {
+				ultra = " -ultra"
+			}
 			choice := discordgo.ApplicationCommandOptionChoice{
-				Name:  fmt.Sprintf("%s (%s)", c.Name, c.ID),
+				Name:  fmt.Sprintf("%s (%s)%s", c.Name, c.ID, ultra),
 				Value: c.ID,
 			}
 			choices = append(choices, &choice)


### PR DESCRIPTION
Adds a " -ultra" suffix to the contract name in the autocomplete
options if the contract is an ultra contract. This provides more
context to the user when selecting a contract from the autocomplete
list.