### PR TITLE
feat(boost): Improve token value calculation and contract order

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -189,12 +189,12 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			b.TokensReceived += count
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: now, Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial, Boost: false})
 			contract.mutex.Unlock()
+			tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+			contract.mutex.Lock()
+			contract.Boosters[fromUserID].TokenValue += tval * float64(count)
+			contract.Boosters[b.UserID].TokenValue -= tval * float64(count)
+			contract.mutex.Unlock()
 			if contract.BoostOrder == ContractOrderTVal {
-				tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-				contract.mutex.Lock()
-				contract.Boosters[fromUserID].TokenValue += tval * float64(count)
-				contract.Boosters[b.UserID].TokenValue -= tval * float64(count)
-				contract.mutex.Unlock()
 				reorderBoosters(contract)
 			}
 			if contract.Style&ContractFlagDynamicTokens != 0 {

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -311,7 +311,8 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 					if contract.State == ContractStateSignup && contract.BoostOrder == ContractOrderELR {
 						sortRate = fmt.Sprintf(" **ELR:%2.3f** ", min(b.ArtifactSet.LayRate, b.ArtifactSet.ShipRate))
 					}
-					if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
+					if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.PlayStyle != ContractPlaystyleChill {
+						//if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
 						sortRate = fmt.Sprintf(" *∆:%2.3f* ", b.TokenValue)
 					}
 
@@ -346,7 +347,8 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 					if contract.State == ContractStateSignup && contract.BoostOrder == ContractOrderELR {
 						sortRate = fmt.Sprintf(" **ELR:%2.3f** ", min(b.ArtifactSet.LayRate, b.ArtifactSet.ShipRate))
 					}
-					if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
+					if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.PlayStyle != ContractPlaystyleChill {
+						//if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
 						sortRate = fmt.Sprintf(" *∆:%2.3f* ", b.TokenValue)
 					}
 
@@ -422,7 +424,8 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 				if contract.State == ContractStateSignup && contract.BoostOrder == ContractOrderELR {
 					sortRate = fmt.Sprintf(" **ELR:%2.3f** ", min(b.ArtifactSet.LayRate, b.ArtifactSet.ShipRate))
 				}
-				if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
+				if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.PlayStyle != ContractPlaystyleChill {
+					//if (contract.State == ContractStateBanker || contract.State == ContractStateFastrun) && contract.BoostOrder == ContractOrderTVal {
 					sortRate = fmt.Sprintf(" *∆:%2.3f* ", b.TokenValue)
 				}
 

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -75,13 +75,13 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: tokensToSend, FromUserID: cUserID, FromNick: contract.Boosters[cUserID].Nick, ToUserID: b.UserID, ToNick: b.Nick, Serial: tokenSerial, Boost: true})
 			contract.mutex.Unlock()
-			if contract.BoostOrder == ContractOrderTVal {
-				tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-				contract.Boosters[cUserID].TokenValue += tval * float64(tokensToSend)
-				contract.Boosters[b.UserID].TokenValue -= tval * float64(tokensToSend)
-				// Don't reorder on the bag send as we need a tiny amount of stability for the send to get to the correct person
-				//reorderBoosters(contract)
-			}
+			//if contract.BoostOrder == ContractOrderTVal {
+			tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+			contract.Boosters[cUserID].TokenValue += tval * float64(tokensToSend)
+			contract.Boosters[b.UserID].TokenValue -= tval * float64(tokensToSend)
+			// Don't reorder on the bag send as we need a tiny amount of stability for the send to get to the correct person
+			//reorderBoosters(contract)
+			//}
 			if contract.Style&ContractFlagDynamicTokens != 0 {
 				// Determine the dynamic tokens
 				determineDynamicTokens(contract)


### PR DESCRIPTION
The changes made in this commit focus on improving the token value calculation and the contract order handling. The key changes are:

1. Moved the token value calculation logic to a separate function call, making the code more readable and maintainable.
2. Removed the dependency on the `ContractOrderTVal` flag, and instead used the `ContractPlaystyleChill` flag to determine the contract order.
3. Simplified the token value update logic by removing the conditional checks based on the contract order.

These changes aim to make the code more robust and easier to understand, while also improving the overall performance of the boost button reactions.