### PR TITLE
feat(boost): Adjust contract grade calculation logic

### DIFF
--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -185,10 +185,6 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 			c.Grade[grade].BasePoints = 187.5 * float64(gradeMult) * goalsCompleted
 		}
 
-		if c.ID == "housing-boom" && grade == 5 {
-			log.Printf("Contract ID is empty for contract %s", c.Name)
-		}
-
 		BTA := c.Grade[grade].EstimatedDuration.Minutes() / float64(c.MinutesPerToken)
 		c.Grade[grade].TargetTval = 3.0
 		if BTA > 42.0 {


### PR DESCRIPTION
Modifies the contract grade calculation logic in the `boost_import.go`
file. Removes the special case handling for the "housing-boom" contract
at grade 5, as it is no longer necessary. This simplifies the code and
makes the grade calculation more consistent across all contracts.