### PR TITLE
feat(boost): Add Grange member list to boost menu

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -561,6 +561,11 @@ func getContractReactionsComponents(contract *Contract) []discordgo.MessageCompo
 		Value: "xpost",
 		Emoji: &discordgo.ComponentEmoji{Name: "🖇️"},
 	})
+	menuOptions = append(menuOptions, discordgo.SelectMenuOption{
+		Label: fmt.Sprintf("%s Grange", contract.Location[0].GuildContractRole.Name),
+		Value: "grange",
+		Emoji: &discordgo.ComponentEmoji{Name: "🧑‍🧑‍🧒‍🧒"},
+	})
 
 	/*
 		menuOptions = append(menuOptions, discordgo.SelectMenuOption{


### PR DESCRIPTION
Adds a new "Grange" option to the boost menu that displays a list of
all Grange members, sorted by their join timestamp. This provides an
easy way for users to see who is part of the Grange and when they
joined.