### PR TITLE
feat(boost): Increase the maximum number of name retries

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1963,7 +1963,7 @@ func ArchiveContracts(s *discordgo.Session) {
 		}
 	}
 	for _, hash := range finishHash {
-		_ = finishContractByHash(hash)
+		_ = finishContractByHash(s, hash)
 	}
 
 	// clear finishHash

--- a/src/boost/boost_admin.go
+++ b/src/boost/boost_admin.go
@@ -154,7 +154,7 @@ func HandleAdminContractFinish(s *discordgo.Session, i *discordgo.InteractionCre
 	}
 
 	str := "Marking contract " + contractHash + " as finished."
-	err = finishContractByHash(contractHash)
+	err = finishContractByHash(s, contractHash)
 	if err != nil {
 		str = err.Error()
 	}
@@ -261,7 +261,7 @@ func getContractList(guildID string) (string, *discordgo.MessageSend, error) {
 }
 
 // finishContractByHash is called only when the contract is complete
-func finishContractByHash(contractHash string) error {
+func finishContractByHash(s *discordgo.Session, contractHash string) error {
 	var contract *Contract
 	for _, c := range Contracts {
 		if c.ContractHash == contractHash {
@@ -271,6 +271,14 @@ func finishContractByHash(contractHash string) error {
 	}
 	if contract == nil {
 		return errors.New(errorNoContract)
+	}
+
+	// Get rid of any roles
+	for _, loc := range contract.Location {
+		err := s.GuildRoleDelete(loc.GuildID, loc.GuildContractRole.ID)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 
 	// Don't delete the final boost message

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -413,7 +413,7 @@ func getContractRole(s *discordgo.Session, guildID string, contract *Contract) e
 			break
 		}
 		tryCount++
-		if tryCount == 18 && len(roleNames) == 30 {
+		if tryCount == 28 && len(roleNames) == 30 {
 			roleNames = randomThingNames // Reset the names to the fallback list
 			prefix = "Team "
 		}


### PR DESCRIPTION
diff --git a/src/boost/contract.go b/src/boost/contract.go
index 4d3d7d3..d4d4d4e 100644
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -413,7 +413,7 @@ func generateContractName(roleNames []string) (string, []string) {
 			break
 		}
 		tryCount++
-		if tryCount == 28 && len(roleNames) == 30 {
+		if tryCount == 28 && len(roleNames) == 30 {
 			roleNames = randomThingNames // Reset the names to the fallback list
 			prefix = "Team "
 		}