### PR TITLE
feat: Add 'pkg' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 output
+pkg
 build
 banners
 ttbb-data


### PR DESCRIPTION
Adds the 'pkg' directory to the .gitignore file to exclude it from
version control. This is necessary as the 'pkg' directory is used to
store compiled packages, which should not be tracked in the repository.