### PR TITLE
feat: Exclude 'pkg' directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.so
 *.dylib
 output
-pkg
 build
 banners
 ttbb-data


### PR DESCRIPTION
Removes the 'pkg' directory from the .gitignore file, allowing
it to be tracked by Git. This change is necessary to ensure
that the 'pkg' directory, which likely contains important
project files, is included in the repository.