### PR TITLE
feat: use nickname instead of full name in boost message

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1784,7 +1784,7 @@ func notifyBellBoosters(s *discordgo.Session, contract *Contract) {
 				duration := t1.Sub(t2)
 				str = fmt.Sprintf("%s: Boosting Completed in %s. Still %d spots in the contract. ", b.ChannelName, duration.Round(time.Second), contract.CoopSize-len(contract.Boosters))
 			default:
-				str = fmt.Sprintf("%s: Send Boost Tokens to %s", b.ChannelName, contract.Boosters[contract.Order[contract.BoostPosition]].Name)
+				str = fmt.Sprintf("%s: Send Boost Tokens to %s", b.ChannelName, contract.Boosters[contract.Order[contract.BoostPosition]].Nick)
 			}
 			_, err := s.ChannelMessageSend(u.ID, str)
 			if err != nil {


### PR DESCRIPTION
The changes in this commit update the boost message to use the nickname of the
booster instead of their full name. This makes the message more concise and
easier to read, especially for longer names. The `Nick` field is used instead
of the `Name` field to retrieve the booster's nickname.