### PR TITLE
feat(boost): Display egg inc name in boost message

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1784,7 +1784,12 @@ func notifyBellBoosters(s *discordgo.Session, contract *Contract) {
 				duration := t1.Sub(t2)
 				str = fmt.Sprintf("%s: Boosting Completed in %s. Still %d spots in the contract. ", b.ChannelName, duration.Round(time.Second), contract.CoopSize-len(contract.Boosters))
 			default:
-				str = fmt.Sprintf("%s: Send Boost Tokens to %s", b.ChannelName, contract.Boosters[contract.Order[contract.BoostPosition]].Nick)
+				var name = contract.Boosters[contract.Order[contract.BoostPosition]].Nick
+				var einame = farmerstate.GetEggIncName(contract.Order[contract.BoostPosition])
+				if einame != "" {
+					name += " " + einame
+				}
+				str = fmt.Sprintf("%s: Send Boost Tokens to %s", b.ChannelName, name)
 			}
 			_, err := s.ChannelMessageSend(u.ID, str)
 			if err != nil {


### PR DESCRIPTION
The changes in this commit add the egg inc name to the boost message if it is available. This provides more context for the user on who they should send the boost tokens to.