### PR TITLE
feat(boost): remove booster from contract

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1097,9 +1097,22 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 		}
 	}
 
+	sinkChanged := false
+
 	// Remove the booster from the contract
+	if userID == contract.Banker.CrtSinkUserID {
+		sinkChanged = true
+		contract.Banker.CrtSinkUserID = ""
+	}
+	if userID == contract.Banker.BoostingSinkUserID {
+		sinkChanged = true
+		contract.Banker.BoostingSinkUserID = ""
+	}
 	if userID == contract.Banker.PostSinkUserID {
+		sinkChanged = true
 		contract.Banker.PostSinkUserID = ""
+	}
+	if sinkChanged {
 		changeContractState(contract, contract.State)
 	}
 


### PR DESCRIPTION
Removes the booster from the contract when the user ID matches
the contract's Banker.CrtSinkUserID, Banker.BoostingSinkUserID, or
Banker.PostSinkUserID. This ensures that the booster is properly
removed from the contract when the user is no longer associated
with it.