### PR TITLE
feat(contract): set sink boost position based on contract duration

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -524,7 +524,6 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, play
 	contract.CreatorID = append(contract.CreatorID, userID)               // starting userid
 	contract.CreatorID = append(contract.CreatorID, config.AdminUsers...) // Admins
 	contract.Speedrun = false
-	contract.Banker.SinkBoostPosition = SinkBoostFollowOrder
 	contract.StartTime = time.Now()
 
 	contract.NewFeature = 1
@@ -532,6 +531,13 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, play
 	contract.CoopSize = coopSize
 	contract.Name = contractID
 	updateContractWithEggIncData(contract)
+
+	// Long contracts default the sink to boosting last
+	// Short contracts default the sink to boosting first
+	contract.Banker.SinkBoostPosition = SinkBoostLast
+	if contract.EstimatedDuration < 10*time.Hour {
+		contract.Banker.SinkBoostPosition = SinkBoostFirst
+	}
 
 	contract.DynamicData = createDynamicTokenData()
 	Contracts[ContractHash] = contract


### PR DESCRIPTION
The changes made in this commit are focused on setting the sink boost position for a contract based on its estimated duration. For long contracts (10 hours or more), the sink boost position is set to `SinkBoostLast`, which means the sink will boost last. For short contracts (less than 10 hours), the sink boost position is set to `SinkBoostFirst`, which means the sink will boost first. This change is intended to improve the overall performance and efficiency of the contract system.