### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,6 +2,8 @@ name: Development
 on: [push, pull_request]
 jobs:
   test-build-upload:
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [1.25]


### PR DESCRIPTION
Potential fix for [https://github.com/mkmccarty/TokenTimeBoostBot/security/code-scanning/22](https://github.com/mkmccarty/TokenTimeBoostBot/security/code-scanning/22)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. The best way is to add the block at the job level (inside `test-build-upload:`), since this workflow only has one job. The minimal required permission is `contents: read` for checking out code. If uploading artifacts does not require additional permissions, this is sufficient. If you later add steps that require more permissions (e.g., creating issues, writing to pull requests), you can expand the block. For now, add the following under the job definition (after line 4):

```yaml
permissions:
  contents: read
```

No imports or other code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
