### PR TITLE
feat(emoji): convert emoji name to lowercase

### DIFF
--- a/src/bottools/app_emoji.go
+++ b/src/bottools/app_emoji.go
@@ -289,7 +289,7 @@ func ImportNewEmojis(s *discordgo.Session) {
 
 			// Create the emoji in Discord
 			data := discordgo.EmojiParams{
-				Name:  emojiName,
+				Name:  strings.ToLower(emojiName),
 				Image: base64Image,
 			}
 			newID, err := s.ApplicationEmojiCreate(config.DiscordAppID, &data)


### PR DESCRIPTION
Converts the emoji name to lowercase before creating the emoji in
Discord. This ensures that the emoji name is consistent with the
existing emoji names in the server.