### PR TITLE
feat(emoji): Allow uppercase emoji names

### DIFF
--- a/src/bottools/app_emoji.go
+++ b/src/bottools/app_emoji.go
@@ -289,7 +289,7 @@ func ImportNewEmojis(s *discordgo.Session) {
 
 			// Create the emoji in Discord
 			data := discordgo.EmojiParams{
-				Name:  strings.ToLower(emojiName),
+				Name:  emojiName,
 				Image: base64Image,
 			}
 			newID, err := s.ApplicationEmojiCreate(config.DiscordAppID, &data)


### PR DESCRIPTION
The changes made in this commit allow for the use of uppercase
characters in the names of emojis created in Discord. Previously,
the code was converting the emoji name to lowercase, which could
result in unexpected behavior or loss of information. By allowing
the original case to be preserved, this change improves the
flexibility and usability of the emoji creation functionality.