### PR TITLE
feat(examples/README.md): Clarify DiscordGuildID setting

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ development bot.
 
 ## DiscordGuildID
 
-This is the server ID for the server you want to restrict the bot to. This is optional.
+This is the server ID for the server you want to restrict the bot to.  When this is set to something then the commands will only be available on that server. To use commands via DM you need to leave this empty. This is an optional setting.
 
 ## OpenAIKey
 


### PR DESCRIPTION
Clarify the purpose and usage of the DiscordGuildID setting in the
examples/README.md file. Explain that when this setting is configured,
the bot commands will only be available on the specified server, and
that leaving it empty allows the commands to be used via DM.