### PR TITLE
feat(boost): handle contract state for token sending

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1465,7 +1465,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 					}
 
 					str = fmt.Sprintf(loc.RoleMention+" send tokens to %s", name)
-				} else {
+				} else if contract.State != ContractStateCRT {
 					if contract.Banker.CurrentBanker == "" {
 						str = loc.RoleMention + " contract boosting complete. Hold your tokens for late joining farmers."
 					} else {

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -303,6 +303,9 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 		if len(progenitors) > contractInfo.MaxCoopSize {
 			progenitors = progenitors[:contractInfo.MaxCoopSize]
 		}
+		if !slices.Contains(progenitors, getInteractionUserID(i)) && len(progenitors) < contractInfo.MaxCoopSize {
+			progenitors = append([]string{getInteractionUserID(i)}, progenitors...)
+		}
 	}
 
 	// Create a new thread for this contract
@@ -396,10 +399,6 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 			SetReactionID(contract, msg.ChannelID, reactionMsg.ID)
 			_ = s.ChannelMessagePin(msg.ChannelID, reactionMsg.ID)
 		}
-		// Auto join the caller into this contract
-		// TODO: This will end up causing a double draw of the contract list
-		//_ = JoinContract(s, i.GuildID, ChannelID, getInteractionUserID(i), false)
-
 	} else {
 		log.Print(err)
 	}


### PR DESCRIPTION
The changes in this commit address the following:

1. Modify the token sending logic to only allow token sending when the contract
   state is not `ContractStateCRT`.
2. Ensure that the interaction user is always included in the list of
   progenitors, even if the list is already at the maximum size.