### PR TITLE
feat(docker): Add emoji directory to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/bot .
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /app
 COPY --from=build /out/bot /app/bot
+COPY emoji /app/emoji
 USER nonroot:nonroot
 ENTRYPOINT ["/app/bot"]


### PR DESCRIPTION
Adds the `emoji` directory to the Docker container, allowing the
bot to access the necessary emoji files for its functionality.
This change ensures the bot can properly display emojis in its
responses.