### PR TITLE
feat: Add context and integration types to slash command

### DIFF
--- a/src/boost/boost_change.go
+++ b/src/boost/boost_change.go
@@ -100,7 +100,13 @@ func GetSlashChangePingRoleCommand(cmd string) *discordgo.ApplicationCommand {
 // GetSlashChangePlannedStartCommand adjust aspects of a running contract
 func GetSlashChangePlannedStartCommand(cmd string) *discordgo.ApplicationCommand {
 	return &discordgo.ApplicationCommand{
-		Name:        cmd,
+		Name: cmd,
+		Contexts: &[]discordgo.InteractionContextType{
+			discordgo.InteractionContextGuild,
+		},
+		IntegrationTypes: &[]discordgo.ApplicationIntegrationType{
+			discordgo.ApplicationIntegrationGuildInstall,
+		},
 		Description: "Change the planned start time of the contract",
 		Options: []*discordgo.ApplicationCommandOption{
 			{


### PR DESCRIPTION
Adds the `Contexts` and `IntegrationTypes` fields to the `GetSlashChangePlannedStartCommand` function in the `boost_change.go` file. This ensures that the slash command is only available in a guild context and for guild-installed integrations, improving the user experience and security of the application.