### PR TITLE
feat(bottools): Save egg image to config.BannerPath directory

### DIFF
--- a/src/bottools/app_emoji.go
+++ b/src/bottools/app_emoji.go
@@ -182,6 +182,11 @@ func ImportEggImage(s *discordgo.Session, eggID, IconURL string) (string, error)
 		return "", err
 	}
 
+	// Write this image to the config.BannerPath directory for banner creation
+	if _, err := os.Stat(config.BannerPath); os.IsNotExist(err) {
+		_ = os.MkdirAll(config.BannerPath, 0755)
+	}
+
 	// Save the image to a file
 	filePath := fmt.Sprintf("%s/egg_%s.png", config.BannerPath, cleanEggID)
 	file, err := os.Create(filePath)
@@ -195,6 +200,7 @@ func ImportEggImage(s *discordgo.Session, eggID, IconURL string) (string, error)
 			log.Printf("Failed to close: %v", err)
 		}
 	}()
+
 	_, err = file.Write(buf.Bytes())
 	if err != nil {
 		log.Print(err)

--- a/src/events/periodicals.go
+++ b/src/events/periodicals.go
@@ -200,13 +200,13 @@ func GetPeriodicalsFromAPI(s *discordgo.Session) {
 		} else if notifyDiscordOfNewEgg {
 			var builder strings.Builder
 			// Do we have an icon for this egg?
-			builder.WriteString(fmt.Sprintf("New Custom Egg Detected: %s", egg.Name))
 			_, err := bottools.ImportEggImage(s, egg.ID, egg.IconURL)
 			if err != nil {
 				log.Print(err)
 				// Can't continue here on error, so skip this egg
 				continue
 			}
+			builder.WriteString(fmt.Sprintf("New Custom Egg Detected: %s", egg.Name))
 
 			description := strings.Join(egg.DimensionValueString, ",") + " " + egg.DimensionName
 			description += fmt.Sprintf("\n%s Value: %g", ei.GetBotEmojiMarkdown(egg.ID), egg.Value)


### PR DESCRIPTION
Saves the egg image to the config.BannerPath directory for banner
creation. This ensures the egg image is available for use in the
banner creation process.