### PR TITLE
feat(boost): Display egg inc name in boost message

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1803,8 +1803,8 @@ func notifyBellBoosters(s *discordgo.Session, contract *Contract) {
 			default:
 				var name = contract.Boosters[contract.Order[contract.BoostPosition]].Nick
 				var einame = farmerstate.GetEggIncName(contract.Order[contract.BoostPosition])
-				if einame != "" {
-					name += " " + einame
+				if einame != "" && einame != name {
+					name += " (" + einame + ")"
 				}
 				str = fmt.Sprintf("%s: Send Boost Tokens to %s", b.ChannelName, name)
 			}


### PR DESCRIPTION
When the egg inc name is not empty and different from the contract
name, append the egg inc name in parentheses to the boost message.
This provides more context to the user about which boost they need
to send.