### PR TITLE
feat: Remove QTargetAmount field from boost struct

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -240,7 +240,6 @@ type Contract struct {
 	EggEmoji                  string
 	TokenStr                  string // Emoji for Token
 	TargetAmount              []float64
-	QTargetAmount             []float64
 	ChickenRunCooldownMinutes int
 	MinutesPerToken           int
 	EstimatedDuration         time.Duration


### PR DESCRIPTION
Removes the QTargetAmount field from the boost struct as it is no longer
required for the current implementation. This simplifies the struct and
reduces the overall complexity of the codebase.