### PR TITLE
feat: Update Google API dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250826171959-ef028d996bc1 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 // indirect
 	google.golang.org/grpc v1.75.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -151,10 +151,10 @@ google.golang.org/api v0.248.0/go.mod h1:yAFUAF56Li7IuIQbTFoLwXTCI6XCFKueOlS7S9e
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20250603155806-513f23925822 h1:rHWScKit0gvAPuOnu87KpaYtjK5zBMLcULh7gxkCXu4=
 google.golang.org/genproto v0.0.0-20250603155806-513f23925822/go.mod h1:HubltRL7rMh0LfnQPkMH4NPDFEWp0jw3vixw7jEM53s=
-google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c h1:AtEkQdl5b6zsybXcbz00j1LwNodDuH6hVifIaNqk7NQ=
-google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c/go.mod h1:ea2MjsO70ssTfCjiwHgI0ZFqcw45Ksuk2ckf9G468GA=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c h1:qXWI/sQtv5UKboZ/zUk7h+mrf/lXORyI+n9DKDAusdg=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c/go.mod h1:gw1tLEfykwDz2ET4a12jcXt4couGAm7IwsVaTy0Sflo=
+google.golang.org/genproto/googleapis/api v0.0.0-20250826171959-ef028d996bc1 h1:APHvLLYBhtZvsbnpkfknDZ7NyH4z5+ub/I0u8L3Oz6g=
+google.golang.org/genproto/googleapis/api v0.0.0-20250826171959-ef028d996bc1/go.mod h1:xUjFWUnWDpZ/C0Gu0qloASKFb6f8/QXiiXhSPFsD668=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 h1:pmJpJEvT846VzausCQ5d7KreSROcDqmO388w5YbnltA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1/go.mod h1:GmFNa4BdJZ2a8G+wCe9Bg3wwThLrJun751XstdJt5Og=
 google.golang.org/grpc v1.75.0 h1:+TW+dqTd2Biwe6KKfhE5JpiYIBWq865PhKGSXiivqt4=
 google.golang.org/grpc v1.75.0/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=

--- a/main.go
+++ b/main.go
@@ -771,6 +771,7 @@ var (
 
 			_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 				Content: str,
+				Flags:   discordgo.MessageFlagsEphemeral,
 			})
 
 		},

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -227,13 +227,6 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 		return components
 	}
 
-	/*
-		if contract.State == ContractStateSignup {
-			builder.WriteString("## Sign-up List\n")
-		} else {
-			builder.WriteString("## Boost List\n")
-		}
-	*/
 	var prefix = " - "
 
 	var earlyList strings.Builder
@@ -483,7 +476,26 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 				}
 			}
 		}
-		//		builder.WriteString(lateList.String())
+
+		if contract.State == ContractStateSignup && len(contract.WaitlistBoosters) > 0 {
+			// Loop through the waitlist and list waitlist folks
+			builder.WriteString("\n### Backups\n")
+			for _, userID := range contract.WaitlistBoosters {
+				userName := "<@" + userID + "> "
+				builder.WriteString(userName)
+			}
+			components = append(components, &discordgo.TextDisplay{
+				Content: builder.String(),
+			})
+			builder.Reset()
+
+			components = append(components, &discordgo.Separator{
+				Divider: &divider,
+				Spacing: &spacing,
+			})
+
+		}
+
 		if builder.Len() != 0 {
 			components = append(components, &discordgo.TextDisplay{
 				Content: builder.String(),

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -303,6 +303,10 @@ func GetSignupComponents(disableStartContract bool, contract *Contract) (string,
 		*/
 
 	}
+	joinMsg := "Join"
+	if contract != nil && len(contract.Boosters) == contract.CoopSize {
+		joinMsg = "Join (Backup)"
+	}
 
 	// Build the return message
 	var buttons []discordgo.MessageComponent
@@ -313,7 +317,7 @@ func GetSignupComponents(disableStartContract bool, contract *Contract) (string,
 				Emoji: &discordgo.ComponentEmoji{
 					Name: "🧑‍🌾",
 				},
-				Label:    "Join",
+				Label:    joinMsg,
 				Style:    discordgo.PrimaryButton,
 				CustomID: "fd_signupFarmer",
 			},


### PR DESCRIPTION
The changes in this commit update the Google API dependencies to the latest versions. Specifically, the `google.golang.org/genproto/googleapis/api` and `google.golang.org/genproto/googleapis/rpc` dependencies have been updated to version `20250826171959-ef028d996bc1`. This update is necessary to ensure compatibility with the latest Google API changes and to keep the project up-to-date.