### PR TITLE
feat(boost): Respect contract boost position for fast-run contracts

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1756,6 +1756,9 @@ func reorderBoosters(contract *Contract) {
 		})
 
 		newBoostPosition := len(orderedNames)
+		if contract.Style&ContractFlagFastrun != 0 {
+			newBoostPosition = contract.BoostPosition
+		}
 
 		// These boosters are all dymanic, any of them could be the next booster
 		for _, pair := range tvalPairs {


### PR DESCRIPTION
Adds a check to respect the contract's boost position when the contract
has the FastRun flag set. This ensures that the boost position is
correctly set for fast-run contracts, which may have a different boost
position than the default.