### PR TITLE
feat(boost): Recalculate token values after duration change

### DIFF
--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -596,6 +596,13 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 			}
 		}
 	}
+	// Recalculate token values after the change
+	targetTval := 3.0
+	BTA := c.EstimatedDuration.Minutes() / float64(c.MinutesPerToken)
+	if BTA > 42.0 {
+		targetTval = 0.07 * BTA
+	}
+	calculateTokenValueCoopLog(c, c.EstimatedDuration, targetTval)
 
 	c.mutex.Unlock()
 	track.ContractTokenUpdate(s, i.ChannelID, &modifiedTokenLog)


### PR DESCRIPTION
Recalculates the token values for a boost contract after the estimated
duration has been modified. This ensures the token values are updated
correctly when the duration changes.