### PR TITLE
feat(boost/contract): Improve role name generation

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"regexp"
 	"slices"
 	"strings"
@@ -439,16 +439,30 @@ func getContractRole(s *discordgo.Session, guildID string, contract *Contract) e
 	tryCount := 0
 	prefix := ""
 
+	// Create a list of unused role names
+	var unusedRoleNames []string
+	for _, name := range roleNames {
+		if !slices.Contains(existingRoles, fmt.Sprintf("%s%s", prefix, name)) {
+			unusedRoleNames = append(unusedRoleNames, name)
+		}
+	}
+	rand.Shuffle(len(unusedRoleNames), func(i, j int) {
+		unusedRoleNames[i], unusedRoleNames[j] = unusedRoleNames[j], unusedRoleNames[i]
+	})
+
 	for {
-		name := roleNames[rand.Intn(len(roleNames))]
+		name := unusedRoleNames[tryCount]
 		if !slices.Contains(existingRoles, name) {
 			// Found an unused name
 			teamName = name
 			break
 		}
 		tryCount++
-		if tryCount == 28 && len(roleNames) == 30 {
-			roleNames = randomThingNames // Reset the names to the fallback list
+		if tryCount == len(unusedRoleNames) {
+			unusedRoleNames = randomThingNames // Reset the names to the fallback list
+			rand.Shuffle(len(unusedRoleNames), func(i, j int) {
+				unusedRoleNames[i], unusedRoleNames[j] = unusedRoleNames[j], unusedRoleNames[i]
+			})
 			prefix = "Team "
 		}
 	}


### PR DESCRIPTION
The changes in this commit improve the role name generation logic in the
`boost/contract.go` file. The key changes are:

- Create a list of unused role names by filtering out the existing roles
  from the full list of role names.
- Shuffle the list of unused role names to ensure a random selection.
- Use the unused role names list instead of the full list of role names to
  find an unused name.
- If the list of unused role names is exhausted, reset it to the fallback
  list of random thing names and shuffle it.
- This change ensures that the role names are selected from the unused
  names, reducing the likelihood of collisions and improving the overall
  name generation process.