### PR TITLE
feat(events): update ACO channel for Colleggtibles

### DIFF
--- a/src/events/periodicals.go
+++ b/src/events/periodicals.go
@@ -221,7 +221,7 @@ func GetPeriodicalsFromAPI(s *discordgo.Session) {
 
 			// Also send this for ACO
 			if !config.IsDevBot() {
-				acoChannel := "1103074428352471050" // ACO #contracts-version-2-chat
+				acoChannel := "1257340301438222401" // ACO #colleggtibles-chat
 				permissions, err := s.UserChannelPermissions(config.DiscordAppID, acoChannel)
 				if err != nil {
 					log.Printf("Error getting permissions for channel %s: %v", acoChannel, err)


### PR DESCRIPTION
The changes update the ACO channel ID used for sending notifications. The
previous channel was for the Contracts version 2 project, but this has
been updated to use the Colleggtibles chat channel instead.