### PR TITLE
feat(contract): Add leaderboard playstyle and update handling

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -113,7 +113,7 @@ const (
 	ContractPlaystyleChill          = 1 // Chill
 	ContractPlaystyleACOCooperative = 2 // ACO Cooperative
 	ContractPlaystyleFastrun        = 3 // Fastrun
-	//ContractPlaystyleLeaderboard    = 4 // Leaderboard
+	ContractPlaystyleLeaderboard    = 4 // Leaderboard
 )
 
 const defaultFamerTokens = 6

--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -397,8 +397,8 @@ func buttonReactionHelp(s *discordgo.Session, i *discordgo.InteractionCreate, co
 		outputStr.WriteString("## [ACO Cooperative Playstyle](https://discord.com/channels/485162044652388384/1386391295869849681/1386598298907050067)\n")
 	case ContractPlaystyleFastrun:
 		outputStr.WriteString("## [Fastrun Playstyle](https://discord.com/channels/485162044652388384/1386391295869849681/1386598380855365784)\n")
-	//case ContractPlaystyleLeaderboard:
-	//	outputStr.WriteString("## [Leaderboard Playstyle](https://discord.com/channels/485162044652388384/1386391295869849681/1386598461184544818)\n")
+	case ContractPlaystyleLeaderboard:
+		outputStr.WriteString("## [Leaderboard Playstyle](https://discord.com/channels/485162044652388384/1386391295869849681/1386598461184544818)\n")
 	case ContractPlaystyleUnset:
 		// No playstyle set, so no link
 	}

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -97,7 +97,6 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 	*/
 	playstyleOptions := []discordgo.SelectMenuOption{}
 
-	//if (contract.Style & ContractFlagCrt) == 0 {
 	playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
 		Label:       "Chill play style",
 		Description: "Everyone fills habs and uses correct artifacts",
@@ -119,15 +118,13 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 		Default:     (contract.PlayStyle == ContractPlaystyleFastrun),
 		Emoji:       ei.GetBotComponentEmoji("fastrun"),
 	})
-	/*} else {
-		playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
-			Label:       "Leaderboard",
-			Description: "Fastrun + Get max CR",
-			Value:       "leaderboard",
-			Default:     (contract.PlayStyle == ContractPlaystyleLeaderboard),
-			Emoji:       ei.GetBotComponentEmoji("leaderboard"),
-		})
-	}*/
+	playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
+		Label:       "Leaderboard",
+		Description: "Banker Run + TBD",
+		Value:       "leaderboard",
+		Default:     (contract.PlayStyle == ContractPlaystyleLeaderboard),
+		Emoji:       ei.GetBotComponentEmoji("leaderboard"),
+	})
 
 	return builder.String(), []discordgo.MessageComponent{
 		discordgo.ActionsRow{


### PR DESCRIPTION
The changes in this commit add support for a new "Leaderboard" playstyle to the contract system. The key changes are:

- Uncomment the previously commented-out "Leaderboard" playstyle option in the contract configuration.
- Update the contract style handling to set the contract style to "Banker" when the playstyle is set to "Leaderboard".
- Add a new case in the `boost_button_reactions.go` file to handle the "Leaderboard" playstyle and display the appropriate Discord channel link.
- Update the `boost_handlers.go` file to include the "Leaderboard" playstyle option in the select menu.

These changes allow users to select the "Leaderboard" playstyle for their contracts, which will automatically configure the contract style to use the "Banker" style.