### PR TITLE
feat: Improve chicken run response message

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -331,7 +331,7 @@ func buttonReactionRunChickens(s *discordgo.Session, contract *Contract, cUserID
 				}
 			}
 		}()
-		str = "You've asked for Chicken Runs, now what...\n...\nMaybe.. check on your habs and gusset?  \nI'm sure you've already forced a game sync so no need to remind about that.\nMaybe self-runs?"
+		str = "You've asked for Chicken Runs, now what...\n...\nMaybe.. check on your habs and gusset?  \nI'm sure you've already forced a game sync so no need to remind about that."
 		return true, str
 	}
 	return false, fmt.Sprintf("You cannot request chicken runs as **%s** hasen't boosted yet.", contract.Boosters[userID].Nick)


### PR DESCRIPTION
The changes made in this commit improve the chicken run response message by
removing the last sentence "Maybe self-runs?". This sentence was not
providing any useful information and was potentially confusing for the
user. The updated message is more concise and focused on the relevant
information.