### PR TITLE
feat(contract): remove CRT-related logic

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -125,6 +125,25 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 	if contract.Location[0].GuildContractRole.ID != "" {
 		builder.WriteString(fmt.Sprintf("> Team Role: %s\n", contract.Location[0].RoleMention))
 	}
+	if contract.Style&ContractFlagBanker != 0 {
+		if contract.Banker.BoostingSinkUserID != "" {
+			fmt.Fprintf(&builder, "> * During boosting send all tokens to **%s**\n", contract.Boosters[contract.Banker.BoostingSinkUserID].Mention)
+			switch contract.Banker.SinkBoostPosition {
+			case SinkBoostFirst:
+				fmt.Fprint(&builder, ">  * Banker boosts **First**\n")
+			case SinkBoostLast:
+				fmt.Fprint(&builder, ">  * Banker boosts **Last**\n")
+			default:
+				fmt.Fprint(&builder, ">  * Banker folows normal boost order\n")
+			}
+
+		} else {
+			fmt.Fprintf(&builder, "> * **Contract cannot start**. Banker required for boosting phase.\n")
+		}
+	}
+	if contract.Banker.PostSinkUserID != "" {
+		fmt.Fprintf(&builder, "> * After contract boosting send all tokens to **%s**\n", contract.Boosters[contract.Banker.PostSinkUserID].Mention)
+	}
 	if contract.Style&ContractStyleFastrun != 0 && contract.Banker.PostSinkUserID != "" {
 		if contract.State != ContractStateSignup && contract.Boosters[contract.Banker.PostSinkUserID] != nil {
 			builder.WriteString(fmt.Sprintf("> Post Contract Sink: **%s**\n", contract.Boosters[contract.Banker.PostSinkUserID].Mention))

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -59,42 +59,6 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 			Name: "💰",
 		},
 	})
-	/*
-		crtOptions := []discordgo.SelectMenuOption{}
-		crtOptions = append(crtOptions, discordgo.SelectMenuOption{
-			Label:       "No-CRT",
-			Description: "Standard vanilla option for this contract",
-			Value:       "no_crt",
-			Default:     (contract.Style & ContractFlagCrt) == 0,
-			Emoji: &discordgo.ComponentEmoji{
-				Name: "🍦",
-			},
-		})
-		crtOptions = append(crtOptions, discordgo.SelectMenuOption{
-			Label:       "CRT",
-			Description: "Chicken Run Tango",
-			Value:       "crt",
-			Default:     (contract.Style&ContractFlagCrt) != 0 && (contract.Style&ContractFlagSelfRuns) == 0,
-			Emoji: &discordgo.ComponentEmoji{
-				Name: "🔁",
-			},
-		})
-
-		if !slices.Contains(config.FeatureFlags, "DISABLE_SELFRUN") {
-			crtOptions = append(crtOptions, discordgo.SelectMenuOption{
-				Label:       "CRT+selfrun",
-				Description: "Less Tango Legs ",
-				Value:       "self_runs",
-				Default:     (contract.Style&ContractFlagCrt) != 0 && (contract.Style&ContractFlagSelfRuns) != 0,
-				Emoji: &discordgo.ComponentEmoji{
-					Name: "🔂",
-				},
-			})
-		} else {
-			// Make sure this flag is cleared if the feature is disabled
-			contract.Style &^= ContractFlagSelfRuns
-		}
-	*/
 	playstyleOptions := []discordgo.SelectMenuOption{}
 
 	playstyleOptions = append(playstyleOptions, discordgo.SelectMenuOption{
@@ -138,19 +102,6 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 				},
 			},
 		},
-		/*
-			discordgo.ActionsRow{
-				Components: []discordgo.MessageComponent{
-					discordgo.SelectMenu{
-						CustomID:    "cs_#crt#" + id,
-						Placeholder: "Choose your options for CRT",
-						MinValues:   &minValues,
-						MaxValues:   1,
-						Options:     crtOptions,
-					},
-				},
-			},
-		*/
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.SelectMenu{
@@ -296,14 +247,6 @@ func GetSignupComponents(disableStartContract bool, contract *Contract) (string,
 		if contract.State != ContractStateSignup {
 			disableStartContract = true
 		}
-		/*
-			// If the contract is both Banker and CRT it needs crt, boost and post sink
-			if contract.Style&ContractFlagBanker != 0 && contract.Style&ContractFlagCrt != 0 {
-				if contract.Banker.CrtSinkUserID == "" || contract.Banker.BoostingSinkUserID == "" || contract.Banker.PostSinkUserID == "" {
-					disableStartContract = true
-				}
-			}
-		*/
 
 	}
 	joinMsg := "Join"
@@ -416,9 +359,6 @@ func GetSignupComponents(disableStartContract bool, contract *Contract) (string,
 			sinkList = append(sinkList, SinkList{"Post Contract Sink", contract.Banker.PostSinkUserID, "postsink"})
 		} else {
 			if contract.State == ContractStateSignup {
-				/*if contract.Style&ContractFlagCrt != 0 {
-					sinkList = append(sinkList, SinkList{"CRT Sink", contract.Banker.CrtSinkUserID, "crtsink"})
-				}*/
 				if contract.Style&ContractFlagBanker != 0 {
 					sinkList = append(sinkList, SinkList{"Boost Sink", contract.Banker.BoostingSinkUserID, "boostsink"})
 				}

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -757,23 +757,6 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	switch cmd {
-	case "crtsink":
-		sid := getInteractionUserID(i)
-		alts := append([]string{sid}, contract.Boosters[sid].Alts...)
-		altIdx := slices.Index(alts, contract.Banker.CrtSinkUserID)
-		if altIdx != -1 {
-			if altIdx != len(alts)-1 {
-				sid = alts[altIdx+1]
-			} else {
-				sid = alts[altIdx] // Allow for the state to reset
-			}
-		}
-
-		if contract.Banker.CrtSinkUserID == sid {
-			contract.Banker.CrtSinkUserID = ""
-		} else if userInContract(contract, sid) {
-			contract.Banker.CrtSinkUserID = sid
-		}
 	case "boostsink":
 		sid := getInteractionUserID(i)
 		alts := append([]string{sid}, contract.Boosters[sid].Alts...)

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -26,7 +26,7 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 		}
 	}
 
-	if cUserID == contract.Banker.BoostingSinkUserID || cUserID == contract.Banker.CrtSinkUserID {
+	if cUserID == contract.Banker.BoostingSinkUserID {
 		var b, sink *Booster
 		b = contract.Boosters[contract.Order[contract.BoostPosition]]
 		// Sink could be CRT Sink or Boosting Sink


### PR DESCRIPTION
The changes in this commit remove the CRT-related logic from the contract management system. The CRT feature was previously used to handle a specific type of contract, but it has now been deprecated and is no longer needed. The changes include:

- Removing the `CrtSinkUserID` field from the `BankerInfo` struct, as well as all the related logic for handling CRT-specific contract states and sink management.
- Removing the CRT-related options from the contract setup UI, as this feature is no longer supported.
- Simplifying the contract state management logic by removing the `ContractStateCRT` state and the associated code.

These changes help to streamline the contract management system by removing unnecessary complexity and focusing on the core functionality required for the current contract types.