### PR TITLE
feat(contract): remove DISABLE_SELFRUN and BANKER_ONLY flags

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -75,14 +75,6 @@ If want to allow other Discord users to have admin permissions you can add their
 
 This list of strings are flags that can be used to enable or disable features in the bot.
 
-### DISABLE_SELFRUN
-
-Adding this will remove the CRT Self run option from the contract settings
-
-### BANKER_ONLY
-
-This will restrict the /contract to always be a banker contract.
-
 ### NO_FUN
 
 This will remove the fun commands from the bot.

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -2,7 +2,6 @@ package boost
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
@@ -34,21 +33,15 @@ func getSignupContractSettings(channelID string, id string, thread bool) (string
 
 	// Dynamic Boost List Styles
 	runStyleOptions := []discordgo.SelectMenuOption{}
-	if !slices.Contains(config.FeatureFlags, "BANKER_ONLY") {
-		runStyleOptions = append(runStyleOptions, discordgo.SelectMenuOption{
-			Label:       "Boost List Style",
-			Description: "Everyone sends tokens to the current booster",
-			Value:       "boostlist",
-			Default:     (contract.Style & ContractFlagFastrun) != 0,
-			Emoji: &discordgo.ComponentEmoji{
-				Name: "📜",
-			},
-		})
-	} else {
-		// Need to clear the defaults of these flags so it's set correctly
-		contract.Style &^= ContractFlagFastrun
-		contract.Style |= ContractFlagBanker
-	}
+	runStyleOptions = append(runStyleOptions, discordgo.SelectMenuOption{
+		Label:       "Boost List Style",
+		Description: "Everyone sends tokens to the current booster",
+		Value:       "boostlist",
+		Default:     (contract.Style & ContractFlagFastrun) != 0,
+		Emoji: &discordgo.ComponentEmoji{
+			Name: "📜",
+		},
+	})
 
 	runStyleOptions = append(runStyleOptions, discordgo.SelectMenuOption{
 		Label:       "Banker Style",


### PR DESCRIPTION
The changes remove the `DISABLE_SELFRUN` and `BANKER_ONLY` flags from the contract settings. This simplifies the contract configuration by removing unnecessary options and ensures that the "Boost List Style" is always available, regardless of the contract type.