### PR TITLE
feat(boost): disable tango leg calculation for CRT contracts

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -898,20 +898,6 @@ func AddFarmerToContract(s *discordgo.Session, contract *Contract, guildID strin
 			contract.CreatorID[0] = userID
 		}
 
-		// Disabling this for now, leave the signup open
-		if contract.State == ContractStateSignup && contract.Style&ContractFlagCrt != 0 {
-			/*
-				if len(contract.Order) == 1 {
-					// Reset contract sink to the first booster to signup
-					contract.Banker.CrtSinkUserID = contract.Order[0]
-					contract.Banker.BoostingSinkUserID = contract.Order[0]
-					contract.Banker.PostSinkUserID = contract.Order[0]
-				}
-			*/
-
-			calculateTangoLegs(contract, true)
-		}
-
 		if !progenitor {
 			if contract.State == ContractStateWaiting {
 				// Reactivate the contract
@@ -1237,7 +1223,6 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 				contract.Banker.BoostingSinkUserID = ""
 				contract.Banker.PostSinkUserID = ""
 			}
-			calculateTangoLegs(contract, true)
 		}
 		msgedit := discordgo.NewMessageEdit(loc.ChannelID, loc.ListMsgID)
 		components := DrawBoostList(s, contract)
@@ -1283,9 +1268,6 @@ func StartContractBoosting(s *discordgo.Session, guildID string, channelID strin
 	}
 
 	reorderBoosters(contract)
-	if contract.State == ContractStateSignup && contract.Style&ContractFlagCrt != 0 {
-		calculateTangoLegs(contract, true)
-	}
 
 	// Set tokens...
 	for i := range contract.Boosters {

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -884,8 +884,6 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 
 	}
 
-	calculateTangoLegs(contract, true)
-
 	for _, loc := range contract.Location {
 		var components []discordgo.MessageComponent
 		msgedit := discordgo.NewMessageEdit(loc.ChannelID, loc.ListMsgID)


### PR DESCRIPTION
The changes made in this commit focus on disabling the tango leg calculation for CRT contracts in the signup state. This change is made to simplify the contract management and leave the signup open for now.

The specific changes are:

- Removed the `calculateTangoLegs` function calls from various parts of the code where the contract is in the signup state and has the CRT flag set.
- Removed the `calculateTangoLegs` function from the `contract.go` file, as it is no longer needed.
- Removed the unused `sumIntSlice` function from the `boost_speedrun.go` file.

These changes aim to simplify the contract management and leave the signup open for now, as the tango leg calculation is not required in the current state of the application.