### PR TITLE
feat(teamwork): Add minimum score metric and update score table

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -111,7 +111,8 @@ func HandleCsEstimatesCommand(s *discordgo.Session, i *discordgo.InteractionCrea
 	footer.WriteString("-# TVAL: Coop Size-1 Chicken Runs & ∆T-Val\n")
 	footer.WriteString("-# SINK: Max Chicken Runs & Token Sink\n")
 	footer.WriteString("-# RUNS: Coop Size-1 Chicken Runs, No token sharing\n")
-	footer.WriteString("-# BASE: No Chicken Runs & No token sharing\n")
+	footer.WriteString("-# MIN:  No Chicken Runs,No token sharing\n")
+	footer.WriteString("-# BASE: No BTV, No Chicken Runs, No token sharing\n")
 	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Flags: flags | discordgo.MessageFlagsIsComponentsV2,
 		Components: []discordgo.MessageComponent{

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -379,16 +379,18 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		sink int64
 		tval int64
 		runs int64
+		min  int64
 		base int64
 	}
 	var contractScoreArr []contractScores
 	var scoresTable strings.Builder
-	fmt.Fprintf(&scoresTable, "`%12s %6s %6s %6s %6s %6s`\n",
+	fmt.Fprintf(&scoresTable, "`%12s %6s %6s %6s %6s %6s %6s`\n",
 		bottools.AlignString("NAME", 12, bottools.StringAlignCenter),
 		bottools.AlignString("MAX", 6, bottools.StringAlignCenter),
 		bottools.AlignString("TVAL", 6, bottools.StringAlignCenter),
 		bottools.AlignString("SINK", 6, bottools.StringAlignCenter),
 		bottools.AlignString("RUNS", 6, bottools.StringAlignCenter),
+		bottools.AlignString("MIN", 6, bottools.StringAlignCenter),
 		bottools.AlignString("BASE", 6, bottools.StringAlignCenter),
 	)
 
@@ -947,6 +949,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 			scoreTval,
 			scoreRuns,
 			scoreMin,
+			scoreBase,
 		})
 
 	}
@@ -1010,9 +1013,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		return contractScoreArr[i].max > contractScoreArr[j].max
 	})
 	for _, cs := range contractScoreArr {
-		fmt.Fprintf(&scoresTable, "`%12s %6d %6d %6d %6d %6d`\n",
+		fmt.Fprintf(&scoresTable, "`%12s %6d %6d %6d %6d %6d %6d`\n",
 			bottools.AlignString(cs.name, 12, bottools.StringAlignLeft),
-			cs.max, cs.tval, cs.sink, cs.runs, cs.base)
+			cs.max, cs.tval, cs.sink, cs.runs, cs.min, cs.base)
 	}
 
 	var siabMax []*discordgo.MessageEmbedField


### PR DESCRIPTION
The changes in this commit add a new metric, "MIN", to the contract score table. This metric represents the score when there are no chicken runs and no token sharing. Additionally, the "BASE" metric has been updated to reflect the score when there is no BTV, no chicken runs, and no token sharing.

These changes provide a more comprehensive view of the contract scores, allowing for better analysis and understanding of the different factors that contribute to the overall score.