### PR TITLE
feat(boost): remove CRT state and related logic

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -77,8 +77,8 @@ const (
 	ContractStateWaiting   = 2 // Waiting for other(s) to join
 	ContractStateCompleted = 3 // Contract is completed
 	ContractStateArchive   = 4 // Contract is ready to archive
-	ContractStateCRT       = 5 // Contract is doing CRT
-	ContractStateBanker    = 6 // Contract is Boosting with Banker
+	//ContractStateCRT       = 5 // Contract is doing CRT [removed]
+	ContractStateBanker = 6 // Contract is Boosting with Banker
 
 	BoostStateUnboosted = 0 // Unboosted
 	BoostStateTokenTime = 1 // TokenTime or turn to receive tokens

--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -718,9 +718,6 @@ func addContractReactionsGather(contract *Contract, tokenStr string) ([]string, 
 	iconsRowB := []string{} //mainly for alt icons
 
 	switch contract.State {
-	case ContractStateCRT:
-		iconsRowA = append(iconsRowA, []string{tokenStr, "✅", "🚚", "🦵", "💰"}...)
-		iconsRowB = append(iconsRowB, contract.AltIcons...)
 	case ContractStateBanker:
 		iconsRowA = append(iconsRowA, []string{tokenStr, "🐓", "💰"}...)
 		iconsRowB = append(iconsRowB, contract.AltIcons...)

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -211,10 +211,6 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 	builder.Reset()
 
 	switch contract.State {
-
-	case ContractStateCRT:
-		//builder.WriteString(fmt.Sprintf("> Send Tokens to <@%s>\n", contract.SRData.SpeedrunStarterUserID))
-
 	case ContractStateBanker:
 		if contract.Banker.CurrentBanker == "" {
 			if contract.Banker.PostSinkUserID != "" {

--- a/src/boost/message_redraw.go
+++ b/src/boost/message_redraw.go
@@ -126,7 +126,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 		}
 
 		switch contract.State {
-		case ContractStateWaiting, ContractStateCRT, ContractStateBanker, ContractStateFastrun:
+		case ContractStateWaiting, ContractStateBanker, ContractStateFastrun:
 			//addContractReactionsButtons(s, contract, loc.ChannelID, msg.ID)
 			if pingUsers {
 				if contract.State == ContractStateFastrun || contract.State == ContractStateBanker {
@@ -143,7 +143,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 					}
 
 					str = fmt.Sprintf(loc.RoleMention+" send tokens to %s", name)
-				} else if contract.State != ContractStateCRT {
+				} else {
 					if contract.Banker.CurrentBanker == "" {
 						str = loc.RoleMention + " contract boosting complete. Hold your tokens for late joining farmers."
 					} else {

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -3,7 +3,6 @@ package boost
 import (
 	"fmt"
 	"log"
-	"slices"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -31,25 +30,6 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 		b = contract.Boosters[contract.Order[contract.BoostPosition]]
 		// Sink could be CRT Sink or Boosting Sink
 		sink = contract.Boosters[cUserID]
-
-		// If this is the CRT then the Bag indicates the sink is boosting
-		if contract.State == ContractStateCRT {
-			b = sink
-			// If sink is already boosted, then just return
-			if b.BoostState == BoostStateBoosted {
-				return false, false
-			}
-
-			// Going to be boosting the sink so make sure they
-			contract.Boosters[contract.Order[contract.BoostPosition]].BoostState = BoostStateUnboosted
-			contract.Boosters[cUserID].StartTime = contract.StartTime
-			contract.Boosters[cUserID].BoostTriggerTime = time.Now()
-			contract.Boosters[cUserID].EndTime = time.Now()
-			contract.Boosters[cUserID].Duration = time.Since(contract.Boosters[cUserID].StartTime)
-			contract.Boosters[contract.Order[contract.BoostPosition]].StartTime = time.Time{}
-			contract.BoostPosition = slices.Index(contract.Order, cUserID)
-			contract.Boosters[contract.Order[contract.BoostPosition]].BoostState = BoostStateTokenTime
-		}
 
 		if cUserID == b.UserID {
 			// Current booster subtract number of tokens wanted


### PR DESCRIPTION
The changes remove the `ContractStateCRT` and related logic from the codebase. This simplifies the contract state management and removes unused functionality. The main changes are:

- Removed the `ContractStateCRT` case from the `boost_button_reactions.go` file, which handled the icons and alt icons for the CRT state.
- Removed the CRT-specific logic from the `state_banker.go` file, which handled the boosting of the CRT sink.
- Removed the CRT-specific code from the `boost_draw.go` and `message_redraw.go` files.
- Removed the `ContractStateCRT` constant from the `boost.go` file.

These changes focus on simplifying the codebase by removing unused functionality and reducing complexity.