### PR TITLE
feat: remove speedrun mode and use contract flags instead

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -275,7 +275,6 @@ type Contract struct {
 	Order               []string
 	BoostedOrder        []string   // Actual order of boosting
 	OrderRevision       int        // Incremented when Order is changed
-	Speedrun            bool       // Speedrun mode
 	Banker              BankerInfo // Banker for the contract
 	TokenLog            []ei.TokenUnitLog
 	TokensPerMinute     float64
@@ -1256,16 +1255,6 @@ func StartContractBoosting(s *discordgo.Session, guildID string, channelID strin
 			contract.Boosters[i].TokensWanted = 8
 		}
 	}
-
-	// Set the CRT Settings to what contract is
-	/*
-		if contract.Style&ContractFlagCrt != 0 {
-			contract.SRData.Legs = contract.SRData.NoSelfRunLegs
-			if contract.Style&ContractFlagSelfRuns != 0 {
-				contract.SRData.Legs = contract.SRData.SelfRunLegs
-			}
-		}
-	*/
 
 	contract.BoostPosition = 0
 	contract.StartTime = time.Now()

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -240,11 +240,7 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkBoosting str
 		}
 	}
 
-	if changeSinksOnly && !contract.Speedrun {
-		return "", errors.New("sinks can only be changed for an existing speedrun contract")
-	}
-
-	if changeSinksOnly && contract.Speedrun {
+	if changeSinksOnly {
 		var builder strings.Builder
 		if sinkBoosting != "" {
 			contract.Banker.BoostingSinkUserID = sinkBoosting
@@ -275,9 +271,6 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkBoosting str
 			contract.Style &= ^ContractFlagSelfRuns
 		}*/
 	contract.Style &= ^ContractFlagSelfRuns
-
-	contract.Speedrun = contract.Style&ContractFlagBanker != 0
-	contract.Speedrun = true // TODO: this will be removed in favor of flags
 
 	// Chicken Runs Calc
 	// Info from https://egg-inc.fandom.com/wiki/Contracts

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -574,7 +574,6 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, play
 	}
 	contract.CreatorID = append(contract.CreatorID, userID)               // starting userid
 	contract.CreatorID = append(contract.CreatorID, config.AdminUsers...) // Admins
-	contract.Speedrun = false
 	contract.StartTime = time.Now()
 
 	contract.NewFeature = 1

--- a/src/boost/message_redraw.go
+++ b/src/boost/message_redraw.go
@@ -179,8 +179,7 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 		}
 
 		// Sending the update message
-		// TODO: Need to figure out just what message to send for banker/fastrun/crt
-		if !contract.Speedrun {
+		if contract.Style&ContractFlagBanker == 0 {
 			_, _ = s.ChannelMessageSend(loc.ChannelID, str)
 		} else if !drawn {
 			_ = RedrawBoostList(s, loc.GuildID, loc.ChannelID)


### PR DESCRIPTION
The changes remove the `Speedrun` field from the contract struct and instead use the `ContractFlagBanker` flag to determine the contract style. This simplifies the code and makes it more flexible, as the contract style can now be determined based on the flags instead of a separate boolean field.

The changes also remove some commented-out code related to CRT settings, as these are no longer needed.