### PR TITLE
feat(boost): update contract style and boost order for leaderboard

### DIFF
--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -60,13 +60,6 @@ func GetSlashSpeedrunCommand(cmd string) *discordgo.ApplicationCommand {
 				MaxValue:    20,
 				Required:    false,
 			},
-			/*
-				{
-					Type:        discordgo.ApplicationCommandOptionBoolean,
-					Name:        "self-runs",
-					Description: "Self Runs during CRT",
-					Required:    false,
-				},*/
 		},
 	}
 }

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -598,6 +598,7 @@ func CreateContract(s *discordgo.Session, contractID string, coopID string, play
 	// Override the contract style based on the play style, only for leaderboard play style
 	if contract.PlayStyle == ContractPlaystyleLeaderboard {
 		contract.Style = ContractFlagBanker
+		contract.BoostOrder = ContractOrderTVal
 	}
 	/*
 		} else { //if !creatorOfContract(contract, userID) {
@@ -822,27 +823,11 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		}
 	}
 
-	/*
-		// A contract that's a CRT is by definition al leaderboard play style
-		if (contract.Style & ContractFlagCrt) != 0 {
-			// strip the Boost list style and set it to banker style
-			contract.Style &= ^ContractFlagFastrun
-			contract.Style |= ContractFlagBanker
-
-			contract.PlayStyle = ContractPlaystyleLeaderboard
-			redrawSignup = true
-			//redrawSettings = true
-		} else if (contract.Style&ContractFlagCrt) == 0 && contract.PlayStyle == ContractPlaystyleLeaderboard {
-			contract.PlayStyle = ContractPlaystyleFastrun
-			redrawSignup = true
-			//redrawSettings = true
-		}
-	*/
-
 	// If the play style changed to leaderboard, then change to use Banker style
 	if contract.PlayStyle == ContractPlaystyleLeaderboard && originalPlayStyle != ContractPlaystyleLeaderboard {
 		contract.Style &= ^ContractFlagFastrun
 		contract.Style |= ContractFlagBanker
+		contract.BoostOrder = ContractOrderTVal
 		redrawSignup = true
 		redrawSettings = true
 	} else if originalPlayStyle == ContractPlaystyleLeaderboard && contract.PlayStyle != ContractPlaystyleLeaderboard {


### PR DESCRIPTION
The changes made in this commit update the contract style and boost order for contracts with a leaderboard play style. Specifically:

- The contract style is set to `ContractFlagBanker` for leaderboard play style contracts.
- The boost order is set to `ContractOrderTVal` for leaderboard play style contracts.
- These changes ensure that the contract style and boost order are properly configured for leaderboard play style contracts.