### PR TITLE
feat(boost): remove join with ping button

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -260,14 +260,16 @@ func GetSignupComponents(disableStartContract bool, contract *Contract) (string,
 				Style:    discordgo.PrimaryButton,
 				CustomID: "fd_signupFarmer",
 			},
-			discordgo.Button{
-				Emoji: &discordgo.ComponentEmoji{
-					Name: "🔔",
+			/*
+				discordgo.Button{
+					Emoji: &discordgo.ComponentEmoji{
+						Name: "🔔",
+					},
+					Label:    "Join w/Ping",
+					Style:    discordgo.PrimaryButton,
+					CustomID: "fd_signupBell",
 				},
-				Label:    "Join w/Ping",
-				Style:    discordgo.PrimaryButton,
-				CustomID: "fd_signupBell",
-			},
+			*/
 			discordgo.Button{
 				Emoji: &discordgo.ComponentEmoji{
 					Name: "❌",

--- a/src/boost/help.go
+++ b/src/boost/help.go
@@ -113,7 +113,7 @@ func GetHelp(s *discordgo.Session, guildID string, channelID string, userID stri
 	if contract != nil {
 
 		if !userInContract(contract, userID) {
-			str := ` See the pinned message for buttons to *Join*, *Join w/Ping* or *Leave* the contract.
+			str := ` See the pinned message for buttons to *Join* or *Leave* the contract.
 		You can set your boost tokens wanted by selecting :five: :six: or :eight: and adjusting it with the +Token and -Token buttons.
 		`
 			field = append(field, &discordgo.MessageEmbedField{


### PR DESCRIPTION
The changes remove the "Join w/Ping" button from the boost handlers. This button was not being used and was causing confusion for users, so it has been removed to simplify the interface.

The changes also update the help message to remove the reference to the "Join w/Ping" button, as it is no longer available.