### PR TITLE
feat: Add banker boost details for active contracts

### DIFF
--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -125,20 +125,22 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 	if contract.Location[0].GuildContractRole.ID != "" {
 		builder.WriteString(fmt.Sprintf("> Team Role: %s\n", contract.Location[0].RoleMention))
 	}
-	if contract.Style&ContractFlagBanker != 0 {
-		if contract.Banker.BoostingSinkUserID != "" {
-			fmt.Fprintf(&builder, "> * During boosting send all tokens to **%s**\n", contract.Boosters[contract.Banker.BoostingSinkUserID].Mention)
-			switch contract.Banker.SinkBoostPosition {
-			case SinkBoostFirst:
-				fmt.Fprint(&builder, ">  * Banker boosts **First**\n")
-			case SinkBoostLast:
-				fmt.Fprint(&builder, ">  * Banker boosts **Last**\n")
-			default:
-				fmt.Fprint(&builder, ">  * Banker folows normal boost order\n")
-			}
+	if contract.State == ContractStateSignup {
+		if contract.Style&ContractFlagBanker != 0 {
+			if contract.Banker.BoostingSinkUserID != "" {
+				fmt.Fprintf(&builder, "> * During boosting send all tokens to **%s**\n", contract.Boosters[contract.Banker.BoostingSinkUserID].Mention)
+				switch contract.Banker.SinkBoostPosition {
+				case SinkBoostFirst:
+					fmt.Fprint(&builder, ">  * Banker boosts **First**\n")
+				case SinkBoostLast:
+					fmt.Fprint(&builder, ">  * Banker boosts **Last**\n")
+				default:
+					fmt.Fprint(&builder, ">  * Banker folows normal boost order\n")
+				}
 
-		} else {
-			fmt.Fprintf(&builder, "> * **Contract cannot start**. Banker required for boosting phase.\n")
+			} else {
+				fmt.Fprintf(&builder, "> * **Contract cannot start**. Banker required for boosting phase.\n")
+			}
 		}
 	}
 	if contract.Banker.PostSinkUserID != "" {


### PR DESCRIPTION
The changes add additional details about the banker's boost position for
active contracts. This information is only displayed for contracts in the
signup state, as the banker's role is only relevant during the boosting
phase. The changes ensure that the correct boost details are shown to
users, improving the overall user experience.