### PR TITLE
feat(teamwork): Add more details to the teamwork output

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -714,9 +714,11 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 						alpha := future.timeEquipped.Sub(startTime).Seconds() / contractDurationSeconds
 						elapsedTimeSec := elapsedSeconds // in seconds
 						eggsShipped := totalContributions / 1e15
+						maxTeamwork.WriteString(fmt.Sprintf("\nTarget Egg Amount: %g\nInitial ELR: %g\nElapsed Time Sec: %g\nEggs Shipped: %g\n",
+							targetEggAmount, initialElr, elapsedTimeSec, eggsShipped))
 						if extraInfo {
-							maxTeamwork.WriteString(fmt.Sprintf("\nTarget Egg Amount: %g\nInitial ELR: %g\nDelta ELR: %g\nAlpha: %g\nElapsed Time Sec: %g\nEggs Shipped: %g\n",
-								targetEggAmount, initialElr, deltaElr, alpha, elapsedTimeSec, eggsShipped))
+							maxTeamwork.WriteString(fmt.Sprintf("\nDelta ELR: %g\nAlpha: %g\n",
+								deltaElr, alpha))
 						}
 
 						switchTime, switchTimestamp, finishTimeWithSwitch, finishTimestampWithSwitch, finishTimeWithoutSwitch, finishTimestampWithoutSwitch, err := ProductionSchedule(


### PR DESCRIPTION
Adds more details to the teamwork output, including the target egg
amount, initial ELR, elapsed time, and eggs shipped. The delta ELR and
alpha values are still included, but moved to a separate section when
the `extraInfo` flag is set.