### PR TITLE
feat(stones): Adjust ELR and Shipping display logic

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -759,9 +759,6 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 		collegELR := chickELR / stoneLayRateNow
 		//fmt.Printf("Calc ELR: %2.3f  Param.Elr: %2.3f   Diff:%2.2f\n", stoneLayRateNow, chickELR, (chickELR / stoneLayRateNow))
 		// No IHR Egg yet, this will need to be revisited
-		if collegELR < 1.00 {
-			collegELR = 1.00
-		}
 		//as.colleggELR = collegELR
 
 		if maxCollectibleELR > 1.0 {
@@ -777,7 +774,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 				val = strings.ReplaceAll(val, ".75", "¾")
 				as.collegg = append(as.collegg, val)
 				//anyColleggtiblesToShow = true
-			} else if collegELR <= 1.0 {
+			} else if collegELR == 1.0 {
 				as.collegg = append(as.collegg, "📦")
 				//anyColleggtiblesToShow = true
 			}
@@ -808,7 +805,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 				as.collegg = append(as.collegg, val)
 
 				//anyColleggtiblesToShow = true
-			} else if collegShip <= 1.0 {
+			} else if collegShip == 1.0 {
 				as.collegg = append(as.collegg, "🚚")
 				//anyColleggtiblesToShow = true
 			}


### PR DESCRIPTION
The changes made in this commit focus on improving the display logic for Egg Laying Rate (ELR) and Shipping in the `stones.go` file. The key changes are:

- Removed the condition to set `collegELR` to 1.00 if it is less than 1.00. This allows the actual calculated value to be used.
- Changed the comparison for displaying the ELR and Shipping icons to use strict equality (`==`) instead of less than or equal to (`<=`). This ensures that the icons are only displayed when the values are exactly 1.0.

These changes help to provide a more accurate and consistent representation of the ELR and Shipping values in the application.