### PR TITLE
feat: Improve token value calculation accuracy

### DIFF
--- a/src/boost/boost_calctval.go
+++ b/src/boost/boost_calctval.go
@@ -2,6 +2,7 @@ package boost
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -144,7 +145,7 @@ func HandleContractCalcContractTvalCommand(s *discordgo.Session, i *discordgo.In
 	} else if !userInContract(contract, userID) {
 		str = "You are not part of this contract"
 	} else {
-		BTA := duration.Minutes() / float64(contract.MinutesPerToken)
+		BTA := math.Floor(duration.Minutes() / float64(contract.MinutesPerToken))
 		targetTval := 3.0
 		if BTA > 42.0 {
 			targetTval = 0.07 * BTA

--- a/src/boost/boost_cooptval.go
+++ b/src/boost/boost_cooptval.go
@@ -2,6 +2,7 @@ package boost
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -91,7 +92,7 @@ func HandleCoopTvalCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 				},
 			})
 		}
-		BTA := duration.Minutes() / float64(contract.MinutesPerToken)
+		BTA := math.Floor(duration.Minutes() / float64(contract.MinutesPerToken))
 		targetTval := 3.0
 		if BTA > 42.0 {
 			targetTval = 0.07 * BTA

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -2,6 +2,7 @@ package boost
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -63,7 +64,7 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 	divider := true
 	spacing := discordgo.SeparatorSpacingSizeSmall
 	targetTval := 3.0
-	BTA := contract.EstimatedDuration.Minutes() / float64(contract.MinutesPerToken)
+	BTA := math.Floor(float64(contract.EstimatedDuration.Minutes()) / float64(contract.MinutesPerToken))
 	if BTA > 42.0 {
 		targetTval = 0.07 * BTA
 	}

--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -186,12 +186,12 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 			c.Grade[grade].BasePoints = 187.5 * float64(gradeMult) * goalsCompleted
 		}
 
-		BTA := c.Grade[grade].EstimatedDuration.Minutes() / float64(c.MinutesPerToken)
+		BTA := math.Floor(float64(c.Grade[grade].EstimatedDuration.Minutes() / float64(c.MinutesPerToken)))
 		c.Grade[grade].TargetTval = 3.0
 		if BTA > 42.0 {
 			c.Grade[grade].TargetTval = 0.07 * BTA
 		}
-		BTALower := c.Grade[grade].EstimatedDurationLower.Minutes() / float64(c.MinutesPerToken)
+		BTALower := math.Floor(float64(c.Grade[grade].EstimatedDurationLower.Minutes() / float64(c.MinutesPerToken)))
 		c.Grade[grade].TargetTvalLower = 3.0
 		if BTALower > 42.0 {
 			c.Grade[grade].TargetTvalLower = 0.07 * BTALower

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -3,6 +3,7 @@ package boost
 import (
 	"fmt"
 	"log"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -598,7 +599,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 	}
 	// Recalculate token values after the change
 	targetTval := 3.0
-	BTA := c.EstimatedDuration.Minutes() / float64(c.MinutesPerToken)
+	BTA := math.Floor(c.EstimatedDuration.Minutes() / float64(c.MinutesPerToken))
 	if BTA > 42.0 {
 		targetTval = 0.07 * BTA
 	}

--- a/src/boost/contract_scores.go
+++ b/src/boost/contract_scores.go
@@ -31,7 +31,7 @@ func calculateChickenRunTeamwork(coopSize int, durationInDays int, runs int) flo
 }
 
 func calculateTokenTeamwork(contractDurationSeconds float64, minutesPerToken int, tokenValueSent float64, tokenValueReceived float64) float64 {
-	BTA := contractDurationSeconds / (float64(minutesPerToken) * 60)
+	BTA := math.Floor(contractDurationSeconds / (float64(minutesPerToken) * 60))
 	T := 0.0
 
 	if BTA <= 42.0 {

--- a/src/track/track.go
+++ b/src/track/track.go
@@ -498,7 +498,7 @@ func getTokenTrackingEmbed(td *tokenValue, finalDisplay bool) *discordgo.Message
 }
 
 func calculateTokenTeamwork(contractDurationSeconds float64, minutesPerToken int, tokenValueSent float64, tokenValueReceived float64) float64 {
-	BTA := contractDurationSeconds / (float64(minutesPerToken) * 60)
+	BTA := math.Floor(contractDurationSeconds / (float64(minutesPerToken) * 60))
 	T := 0.0
 
 	if BTA <= 42.0 {


### PR DESCRIPTION
This change improves the accuracy of token value calculations by using the `math.Floor()` function to round down the BTA (Blocks to Approval) value instead of using a simple division. This ensures that the BTA value is always an integer, which is more accurate for the token value calculations.

The changes were made in the following files:

- `src/boost/boost_draw.go`
- `src/track/track.go`
- `src/boost/boost_cooptval.go`
- `src/boost/boost_import.go`
- `src/boost/boost_calctval.go`
- `src/boost/boost_slashcmd.go`
- `src/boost/contract_scores.go`

The main motivation for these changes is to improve the overall accuracy of the token value calculations, which are crucial for the correct functioning of the application.