### PR TITLE
feat: Add volunteer sink for all fastrun contracts

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -344,8 +344,7 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 
 	var sinkList []SinkList
 
-	// Volunteer Sink is only for fastrun contracts without a CRT
-	if contract.Style&ContractFlagFastrun != 0 && contract.Style&ContractFlagCrt == 0 {
+	if contract.Style&ContractFlagFastrun != 0 {
 		sinkList = append(sinkList, SinkList{"Post Contract Sink", contract.Banker.PostSinkUserID, "postsink"})
 	} else {
 		if contract.State == ContractStateSignup {


### PR DESCRIPTION
Adds a volunteer sink for all fastrun contracts, regardless of whether
they have a CRT or not. This ensures that all fastrun contracts have a
sink to handle their post-contract processing.