### PR TITLE
feat: Improve SIAB artifact swap logic

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -678,8 +678,12 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 
 						// Calculate the saved number of seconds
 						//maxTeamwork.WriteString(fmt.Sprintf("Increased contribution rate of %2.3g%% swapping %d slot SIAB with a 3 slot artifact and speeding the contract by %v\n", (adjustedContributionRate-1)*100, siabStones, diffSeconds))
-						maxTeamwork.WriteString(fmt.Sprintf("Increased contribution rate of %2.3g%% swapping %d slot SIAB with a 3 slot %s.\n",
-							(future.contributionRateInSeconds/siab.contributionRateInSeconds-1)*100, siabStones, swapArtifactName))
+						newSlots := 3
+						if swapArtifactName == "Compass" {
+							newSlots = 2
+						}
+						maxTeamwork.WriteString(fmt.Sprintf("Increased contribution rate of %2.3g%% swapping %d slot SIAB with a %d slot %s.\n",
+							(future.contributionRateInSeconds/siab.contributionRateInSeconds-1)*100, siabStones, newSlots, swapArtifactName))
 						siabSwapMap[MostRecentDuration.Add(siabTimeEquipped).Unix()] = fmt.Sprintf("<t:%d:t> %s\n", MostRecentDuration.Add(siabTimeEquipped).Unix(), name)
 
 						if shortTeamwork == 0 {


### PR DESCRIPTION
Modify the logic for swapping SIAB artifacts to handle the
special case of the Compass artifact, which has 2 slots instead
of the usual 3 slots. Update the output message to reflect the
correct number of slots for the swapped artifact.