### PR TITLE
feat(stones): Add ELR colleggtible to Staabmia link

### DIFF
--- a/src/boost/stones.go
+++ b/src/boost/stones.go
@@ -242,6 +242,7 @@ type artifactSet struct {
 	soloData       [][]string
 	staabArtifacts []string
 	colleggSR      float64
+	colleggELR     float64
 	artifactSlots  []string // Name of artifacts in each slot
 	//colleggELR     float64
 	//colleggHab     float64
@@ -759,7 +760,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 		collegELR := chickELR / stoneLayRateNow
 		//fmt.Printf("Calc ELR: %2.3f  Param.Elr: %2.3f   Diff:%2.2f\n", stoneLayRateNow, chickELR, (chickELR / stoneLayRateNow))
 		// No IHR Egg yet, this will need to be revisited
-		//as.colleggELR = collegELR
+		as.colleggELR = math.Round(collegELR*1000) / 1000
 
 		if maxCollectibleELR > 1.0 {
 			roundedCollegELR := math.Round(collegELR*1000) / 1000
@@ -792,10 +793,10 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 		}
 		//fmt.Printf("Calc SR: %2.3f  param.Sr: %2.3f   Diff:%2.2f\n", stoneShipRateNow, as.sr/1e15, (as.sr/1e15)/stoneShipRateNow)
 		collegShip := (as.sr / 1e15) / stoneShipRateNow
-		as.colleggSR = collegShip
+		as.colleggSR = math.Round(collegShip*10000) / 10000
 
 		if maxColllectibleShip > 1.0 {
-			roundedCollegShip := math.Round(collegShip*1000) / 1000
+			roundedCollegShip := math.Round(collegShip*10000) / 10000
 			if roundedCollegShip > 1.000 && roundedCollegShip < maxColllectibleShip {
 				val := fmt.Sprintf("%2.2f🚚", (roundedCollegShip-1.0)*100.0)
 				val = strings.ReplaceAll(val, ".00", "")
@@ -1020,7 +1021,7 @@ func DownloadCoopStatusStones(contractID string, coopID string, details bool, so
 			tableData = append(tableData, strings.Join(statsLine, " "))
 
 			if as.name != "[departed]" {
-				url := bottools.GetStaabmiaLink(true, dimension, rate, int(everyoneDeflectorPercent), as.staabArtifacts, as.colleggSR)
+				url := bottools.GetStaabmiaLink(true, dimension, rate, int(everyoneDeflectorPercent), as.staabArtifacts, as.colleggSR, as.colleggELR)
 				builderURL.WriteString(fmt.Sprintf("🔗[%s](%s)\n", as.nameRaw, url))
 				fmt.Fprintf(&tileBuilder, "[%sCalc](%s)", ei.GetBotEmojiMarkdown("staab"), url)
 			}

--- a/src/bottools/staabmia_link.go
+++ b/src/bottools/staabmia_link.go
@@ -146,10 +146,16 @@ func parseInt(s string) uint64 {
 }
 
 // GetStaabmiaLink returns a link to the Staabia calculator.
-func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, modifierMult float64, coopDeflectorBonus int, artifacts []string, shippingRate float64) string {
+/*
+I posted the new version of stone calculator (v-5). It should be backwards compatible, so absolutely no rush on the changes, it'll just assume 5% for the ELR colleggtible with v-4 inputs. I believe you just need to:
+change to v-5
+apply the colleggtible to the correct position, see the order here in the gatherData() function, variable itemsToSweep
+I removed the 4% option, so you'll have to map 5% to index 0, 3% to index 1, 2% to index 2, etc.*/
+
+func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, modifierMult float64, coopDeflectorBonus int, artifacts []string, shippingRate float64, elrRate float64) string {
 	link := "https://srsandbox-staabmia.netlify.app/stone-calc?data="
-	version := "v-4"
-	itemsToSweep := []string{"Padding", "DarkMode", "Metro", "Comp", "Gusset", "Defl", "ShipColleggtibles", "ShipColleggtibles2", "Modifiers", "DeflectorSelect"}
+	version := "v-5"
+	itemsToSweep := []string{"Padding", "DarkMode", "Metro", "Comp", "Gusset", "Defl", "ShipColleggtibles", "ShipColleggtibles2", "ELRColleggtibles", "Modifiers", "DeflectorSelect"}
 	itemsData := make([]string, len(itemsToSweep))
 
 	// Build Base64 data
@@ -235,10 +241,10 @@ func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, 
 	// Determine the combination of multipliers for shippingRate
 	multipliers := []float64{1.0, 1.01, 1.02, 1.03, 1.05}
 	multiplierMap := map[float64]string{
-		1.0:  "05",
-		1.01: "04",
-		1.02: "03",
-		1.03: "02",
+		1.0:  "04",
+		1.01: "03",
+		1.02: "02",
+		1.03: "01",
 		1.05: "00",
 	}
 
@@ -255,8 +261,9 @@ func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, 
 			}
 		}
 	}
+	itemsData[8] = multiplierMap[elrRate]
 
-	itemsData[8] = "00" // Default this to unset
+	itemsData[9] = "00" // Default this to unset
 	switch modifierType {
 	case ei.GameModifier_EGG_LAYING_RATE:
 		itemsData[8] = "01"


### PR DESCRIPTION
The changes made in this commit include:

1. Added a new field `colleggELR` to the `stones.go` file to store the calculated Egg Laying Rate (ELR) colleggtible.
2. Updated the calculation of `colleggELR` to round the value to 3 decimal places.
3. Updated the calculation of `colleggSR` to round the value to 4 decimal places.
4. Updated the `GetStaabmiaLink` function in `staabmia_link.go` to include the `elrRate` parameter and pass it to the Staabmia calculator.
5. Updated the mapping of the colleggtible multipliers in the `GetStaabmiaLink` function to match the new version (v-5) of the Staabmia calculator.

These changes were made to ensure that the Staabmia calculator is using the correct ELR colleggtible value and to align with the latest version of the calculator.