### PR TITLE
feat(siab): Remove debug print statement for contract duration

### DIFF
--- a/src/boost/siab.go
+++ b/src/boost/siab.go
@@ -1142,7 +1142,7 @@ func ProductionSchedule(
 		return time.Time{}, 0, time.Time{}, 0, time.Time{}, 0, fmt.Errorf("cannot calculate total contract duration: denominator is zero (initialElr + deltaElr*(1 - alpha) = 0)")
 	}
 	totalContractDuration := (remainingEggAmount + initialElr*elapsedTimeHours) / denominatorDuration // in hours
-	fmt.Printf("Total contract duration: %.2f hours\n", totalContractDuration)
+	//fmt.Printf("Total contract duration: %.2f hours\n", totalContractDuration)
 
 	// Calculate elapsed time at which the switch occurs
 	elapsedTimeAtSwitch := alpha * totalContractDuration // in hours


### PR DESCRIPTION
The changes remove a debug print statement that was printing the total contract duration. This print statement was not necessary for the functionality of the code and was removed to reduce clutter and improve the overall code readability.