### PR TITLE
feat: update contract banker after completion

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -733,13 +733,13 @@ func addContractReactionsGather(contract *Contract, tokenStr string) ([]string, 
 		iconsRowA = append(iconsRowA, "🐓")
 
 	case ContractStateCompleted:
+		contract.Banker.CurrentBanker = contract.Banker.PostSinkUserID
 		sinkID := contract.Banker.CurrentBanker
 		if sinkID != "" {
 			iconsRowA = append(iconsRowA, tokenStr)
 			iconsRowB = append(iconsRowB, contract.AltIcons...)
 		}
 		iconsRowA = append(iconsRowA, "🐓")
-
 	}
 
 	gg, ugg, _ := ei.GetGenerousGiftEvent()


### PR DESCRIPTION
The changes update the `contract.Banker.CurrentBanker` field to the
`contract.Banker.PostSinkUserID` value when the contract state is
`ContractStateCompleted`. This ensures that the current banker is
correctly set after the contract has been completed.