### PR TITLE
feat(boost): add parade host functionality

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -159,6 +159,16 @@ type ArtifactSet struct {
 	ShipRate  float64
 }
 
+// Kind represents the type of booster
+type Kind int
+
+const (
+	// Normal Booster Farmer
+	Normal Kind = iota
+	// Parade Farmer Slot
+	Parade
+)
+
 // Booster holds the data for each booster within a Contract
 type Booster struct {
 	UserID      string // Egg Farmer
@@ -198,6 +208,8 @@ type Booster struct {
 	EstEndOfBoost          time.Time     // Estimated end of the boost
 	EstRequestChickenRuns  time.Time     // Estimated time to request chicken runs
 	Ultra                  bool          // Does this player have Ultra
+	// Alt Parade
+	Kind Kind
 }
 
 // LocationData holds server specific Data for a contract
@@ -218,6 +230,7 @@ type LocationData struct {
 // BankerInfo holds information about contract Banker
 type BankerInfo struct {
 	CurrentBanker      string // Current Banker
+	ParadeSinkUserID   string // Alt Parade Sink User ID
 	BoostingSinkUserID string // Boosting Sink User ID
 	PostSinkUserID     string // Sink End of Contract User ID
 	SinkBoostPosition  int    // Sink Boost Position
@@ -229,9 +242,8 @@ type Contract struct {
 	Location     []*LocationData
 	CreatorID    []string // Slice of creators
 	//SignupMsgID    map[string]string // Message ID for the Signup Message
-	ContractID string // Contract ID
-	CoopID     string // CoopID
-
+	ContractID                string // Contract ID
+	CoopID                    string // CoopID
 	Name                      string
 	Description               string
 	Egg                       int32
@@ -723,6 +735,7 @@ func AddFarmerToContract(s *discordgo.Session, contract *Contract, guildID strin
 	if b == nil {
 		// New Booster - add them to boost list
 		var b = new(Booster)
+		b.Kind = Normal
 		b.Register = time.Now()
 		b.UserID = userID
 		b.Color = 0x00cc00

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -757,6 +757,34 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	switch cmd {
+	case "paradehost":
+		sid := getInteractionUserID(i)
+		switch contract.Boosters[sid].Kind {
+		case Normal:
+			contract.Boosters[sid].Kind = Parade
+		case Parade:
+			contract.Boosters[sid].Kind = Normal
+		}
+	case "paradesink":
+		sid := getInteractionUserID(i)
+		alts := append([]string{sid}, contract.Boosters[sid].Alts...)
+		altIdx := slices.Index(alts, contract.Banker.ParadeSinkUserID)
+		if altIdx != -1 {
+			if altIdx != len(alts)-1 {
+				sid = alts[altIdx+1]
+			} else {
+				sid = alts[altIdx] // Allow for the state to reset
+			}
+		}
+
+		if contract.Banker.ParadeSinkUserID == sid {
+			contract.Boosters[sid].Kind = Normal
+			contract.Banker.ParadeSinkUserID = ""
+		} else if userInContract(contract, sid) {
+			contract.Banker.ParadeSinkUserID = sid
+			contract.Boosters[sid].Kind = Parade
+		}
+
 	case "boostsink":
 		sid := getInteractionUserID(i)
 		alts := append([]string{sid}, contract.Boosters[sid].Alts...)

--- a/src/bottools/staabmia_link.go
+++ b/src/bottools/staabmia_link.go
@@ -272,7 +272,7 @@ func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, 
 	case ei.GameModifier_HAB_CAPACITY:
 		itemsData[8] = "00"
 	}
-	itemsData[9] = "01" // DeflectorSelect for All Deflectors
+	itemsData[10] = "01" // DeflectorSelect for All Deflectors
 	base62encoded := chunk16(strings.Join(itemsData, ""))
 
 	return link + version + base64encoded + "=" + base62encoded


### PR DESCRIPTION
This commit adds the ability for a booster to volunteer as a parade host. The changes include:

- Add a new `Kind` type to represent the type of booster (Normal or Parade)
- Add a `ParadeSinkUserID` field to the `BankerInfo` struct to track the parade sink user ID
- Append a "Parade Host" button to the sink list if the contract has a leaderboard playstyle
- Update the `Booster` struct to include a `Kind` field, which is set to `Normal` by default for new boosters
- Handle the `paradehost` command in the `contract.go` file to allow a booster to volunteer as a parade host

These changes enable the parade functionality for contracts, allowing boosters to volunteer their slots for the parade.