### PR TITLE
feat(bottools): update staabmia_link.go to fix modifier types

### DIFF
--- a/src/bottools/staabmia_link.go
+++ b/src/bottools/staabmia_link.go
@@ -266,11 +266,11 @@ func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, 
 	itemsData[9] = "00" // Default this to unset
 	switch modifierType {
 	case ei.GameModifier_EGG_LAYING_RATE:
-		itemsData[8] = "01"
+		itemsData[9] = "01"
 	case ei.GameModifier_SHIPPING_CAPACITY:
-		itemsData[8] = "02"
+		itemsData[9] = "02"
 	case ei.GameModifier_HAB_CAPACITY:
-		itemsData[8] = "00"
+		itemsData[9] = "00"
 	}
 	itemsData[10] = "01" // DeflectorSelect for All Deflectors
 	base62encoded := chunk16(strings.Join(itemsData, ""))


### PR DESCRIPTION
The changes in this commit fix the assignment of modifier types in the
staabmia_link.go file. The previous code was incorrectly setting the
modifier type in the wrong array index. This commit updates the code to
correctly set the modifier type in the appropriate array index.