### PR TITLE
feat(contract): Set current banker when contract is in banker state

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -348,7 +348,7 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 		sinkList = append(sinkList, SinkList{"Parade Banker", "🎪", contract.Banker.ParadeSinkUserID, "paradesink"})
 		sinkList = append(sinkList, SinkList{"Parade Host", "🤹", "", "paradehost"})
 	}
-	if contract.State == ContractStateSignup && contract.Style&ContractFlagBanker != 0 {
+	if contract.Style&ContractFlagBanker != 0 {
 		sinkList = append(sinkList, SinkList{"Banker", "🏦", contract.Banker.BoostingSinkUserID, "boostsink"})
 	}
 	sinkList = append(sinkList, SinkList{"Post Contract Sink", "🏁", contract.Banker.PostSinkUserID, "postsink"})
@@ -369,7 +369,7 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 		})
 	}
 
-	if contract.State == ContractStateSignup && contract.Style&ContractFlagBanker != 0 {
+	if contract.Style&ContractFlagBanker != 0 {
 		name := ""
 		switch contract.Banker.SinkBoostPosition {
 		case SinkBoostFirst:
@@ -400,9 +400,8 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 				})
 			}
 		}
-
-		buttons = append(buttons, discordgo.ActionsRow{Components: mComp})
 	}
+	buttons = append(buttons, discordgo.ActionsRow{Components: mComp})
 
 	return str, buttons
 }

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -802,6 +802,9 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		} else if userInContract(contract, sid) {
 			contract.Banker.BoostingSinkUserID = sid
 		}
+		if contract.State == ContractStateBanker {
+			contract.Banker.CurrentBanker = contract.Banker.BoostingSinkUserID
+		}
 	case "postsink":
 		sid := getInteractionUserID(i)
 		alts := append([]string{sid}, contract.Boosters[sid].Alts...)


### PR DESCRIPTION
The changes made in this commit are:

1. Added a new condition to set the `contract.Banker.CurrentBanker` field when the contract is in the `ContractStateBanker` state.
2. Simplified the condition for displaying the "Banker" sink in the `boost_handlers.go` file by removing the check for the `ContractStateSignup` state.
3. Moved the appending of the `discordgo.ActionsRow` to the end of the function in `boost_handlers.go` to ensure that the buttons are always added to the response.

These changes are made to ensure that the current banker is correctly set when the contract is in the banker state, and to simplify the logic for displaying the "Banker" sink.