### PR TITLE
feat(boost/handlers): Add Banker sink for signup and banker states

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -348,7 +348,7 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 		sinkList = append(sinkList, SinkList{"Parade Banker", "🎪", contract.Banker.ParadeSinkUserID, "paradesink"})
 		sinkList = append(sinkList, SinkList{"Parade Host", "🤹", "", "paradehost"})
 	}
-	if contract.Style&ContractFlagBanker != 0 {
+	if (contract.State == ContractStateSignup || contract.State == ContractStateBanker) && contract.Style&ContractFlagBanker != 0 {
 		sinkList = append(sinkList, SinkList{"Banker", "🏦", contract.Banker.BoostingSinkUserID, "boostsink"})
 	}
 	sinkList = append(sinkList, SinkList{"Post Contract Sink", "🏁", contract.Banker.PostSinkUserID, "postsink"})
@@ -369,7 +369,7 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 		})
 	}
 
-	if contract.Style&ContractFlagBanker != 0 {
+	if (contract.State == ContractStateSignup || contract.State == ContractStateBanker) && contract.Style&ContractFlagBanker != 0 {
 		name := ""
 		switch contract.Banker.SinkBoostPosition {
 		case SinkBoostFirst:


### PR DESCRIPTION
The changes add a new Banker sink to the sink list when the contract is in the
Signup or Banker state and the contract has the Banker flag set. This ensures
that the Banker sink is only displayed during the appropriate contract states.