### PR TITLE
feat: Implement contract score estimation and display archived contracts

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ const slashArtifact string = "artifact"
 const slashScoreExplorer string = "score-explorer"
 const slashRemoveDMMessage string = "remove-dm-message"
 const slashPrivacy string = "privacy"
+const slashRerunEval string = "rerun-eval"
 
 var integerZeroMinValue float64 = 0.0
 
@@ -176,6 +177,7 @@ var (
 		events.SlashEventHelperCommand(slashEventHelper),
 		track.GetSlashTokenCommand(slashToken),
 		track.GetSlashTokenEditTrackCommand(slashTokenEditTrack),
+		boost.GetSlashReplayEvalCommand(slashRerunEval),
 	}
 
 	commands = []*discordgo.ApplicationCommand{
@@ -489,6 +491,9 @@ var (
 		slashEventHelper: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			events.HandleEventHelper(s, i)
 		},
+		slashRerunEval: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleReplayEval(s, i)
+		},
 		slashToken: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleTokenCommand(s, i)
 		},
@@ -761,6 +766,9 @@ var (
 		},
 		"fd_signupBell": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			joinContract(s, i, true)
+		},
+		"m_replay": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleReplayModalSubmit(s, i)
 		},
 		"fd_signupLeave": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			str := "Removed from Contract"

--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -223,6 +223,18 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 		c.EstimatedDuration, c.EstimatedDurationLower = getContractDurationEstimate(c.TargetAmount[len(c.TargetAmount)-1], float64(c.MaxCoopSize), c.LengthInSeconds,
 			c.ModifierSR, c.ModifierELR, c.ModifierHabCap)
 	}
+
+	if c.ContractVersion == 2 {
+		score := getContractScoreEstimate(c, ei.Contract_GRADE_AAA,
+			true, 1.0, // Use faster duration at a 1.0 modifier
+			1.05,    // Fair Share, first booster
+			100, 20, // SIAB 100%, 20 minutes
+			20, 10, // Deflector %, minutes reduction
+			c.ChickenRuns, // All Chicken Runs
+			100, 5)        // Tokens Sent a lot and received a little.
+		c.Cxp = float64(score)
+	}
+
 	return c
 }
 

--- a/src/boost/replay.go
+++ b/src/boost/replay.go
@@ -1,0 +1,245 @@
+package boost
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// GetSlashReplayEvalCommand returns the command for the /launch-helper command
+func GetSlashReplayEvalCommand(cmd string) *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        cmd,
+		Description: "Evaluate contract history and provide replay guidance.",
+		Contexts: &[]discordgo.InteractionContextType{
+			discordgo.InteractionContextGuild,
+			discordgo.InteractionContextBotDM,
+			discordgo.InteractionContextPrivateChannel,
+		},
+		IntegrationTypes: &[]discordgo.ApplicationIntegrationType{
+			discordgo.ApplicationIntegrationGuildInstall,
+			discordgo.ApplicationIntegrationUserInstall,
+		},
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "reset",
+				Description: "Reset stored data and start fresh",
+				Required:    false,
+			},
+		},
+	}
+}
+
+// HandleReplayEval handles the /replay-eval command
+func HandleReplayEval(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	userID := bottools.GetInteractionUserID(i)
+
+	options := i.ApplicationCommandData().Options
+	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
+	for _, opt := range options {
+		optionMap[opt.Name] = opt
+	}
+
+	if opt, ok := optionMap["reset"]; ok {
+		if opt.BoolValue() {
+			farmerstate.SetMiscSettingString(userID, "encrypted_ei_id", "")
+		}
+	}
+
+	eggIncID := ""
+	eiID := farmerstate.GetMiscSettingString(userID, "encrypted_ei_id")
+	encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+	if err == nil {
+		decodedData, err := base64.StdEncoding.DecodeString(eiID)
+		if err == nil {
+			decryptedData, err := decryptCombined(encryptionKey, decodedData)
+			if err == nil {
+				eggIncID = string(decryptedData)
+			}
+		}
+	}
+
+	if eggIncID == "" || len(eggIncID) != 18 || eggIncID[:2] != "EI" {
+		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseModal,
+			Data: &discordgo.InteractionResponseData{
+				CustomID: "m_replay#" + userID,
+				Title:    "BoostBot needs your Egg Inc ID",
+				Components: []discordgo.MessageComponent{
+					discordgo.ActionsRow{
+						Components: []discordgo.MessageComponent{
+							discordgo.TextInput{
+								CustomID:    "egginc-id",
+								Label:       "Egg Inc game ID (El+16 numbers) *",
+								Style:       discordgo.TextInputShort,
+								Placeholder: "EI0000000000000000",
+								MaxLength:   18,
+								Required:    true,
+							},
+						}},
+				}}})
+		if err != nil {
+			log.Println(err.Error())
+		}
+		return
+	}
+
+	// Do the work
+	flags := discordgo.MessageFlagsIsComponentsV2
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "Processing request...",
+			Flags:   flags,
+		},
+	})
+
+	str := ei.GetContractArchiveFromAPI(s, eggIncID)
+	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Flags: flags,
+		Components: []discordgo.MessageComponent{
+			discordgo.TextDisplay{Content: str},
+		},
+	})
+
+}
+
+// HandleReplayModalSubmit handles the modal submission for the /replay-eval command
+func HandleReplayModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	eggIncID := ""
+	str := "That's not a valid Egg Inc ID. It should start with EI followed by 16 numbers."
+	userID := bottools.GetInteractionUserID(i)
+	modalData := i.ModalSubmitData()
+	for _, comp := range modalData.Components {
+		input := comp.(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput)
+		if input.CustomID == "egginc-id" && input.Value != "" {
+			eggIncID := strings.TrimSpace(input.Value)
+			if len(eggIncID) != 18 || eggIncID[:2] != "EI" || !utf8.ValidString(eggIncID) {
+				break
+			}
+			encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+			if err == nil {
+				combinedData, err := encryptAndCombine(encryptionKey, []byte(eggIncID))
+				if err == nil {
+					farmerstate.SetMiscSettingString(userID, "encrypted_ei_id", base64.StdEncoding.EncodeToString(combinedData))
+					str = "Egg Inc ID saved."
+				}
+			}
+		}
+	}
+
+	flags := discordgo.MessageFlagsIsComponentsV2
+	if eggIncID == "" {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: str,
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Do the work
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: str,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+
+	str = ei.GetContractArchiveFromAPI(s, eggIncID)
+	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Flags: flags,
+		Components: []discordgo.MessageComponent{
+			discordgo.TextDisplay{Content: str},
+		},
+	})
+}
+
+/*
+// The size of the AES key. 32 bytes for AES-256.
+const keySize = 32
+// generateKey creates a new, random 32-byte key for AES-256.
+func generateKey() ([]byte, error) {
+	key := make([]byte, keySize)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate key: %w", err)
+	}
+	return key, nil
+}
+*/
+
+// encryptAndCombine performs AES-GCM encryption and returns the
+// nonce and ciphertext combined into a single byte slice.
+func encryptAndCombine(key []byte, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM instance: %w", err)
+	}
+
+	// Create a new, unique nonce.
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Seal the plaintext, which returns the ciphertext.
+	ciphertext := aesgcm.Seal(nil, nonce, plaintext, nil)
+
+	// Prepend the nonce to the ciphertext.
+	combined := append(nonce, ciphertext...)
+
+	return combined, nil
+}
+
+// decryptCombined performs AES-GCM decryption on a combined byte slice.
+// It splits the nonce from the ciphertext and then decrypts the data.
+func decryptCombined(key []byte, combined []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM instance: %w", err)
+	}
+
+	nonceSize := aesgcm.NonceSize()
+	if len(combined) < nonceSize {
+		return nil, fmt.Errorf("invalid combined data: too short to contain nonce")
+	}
+
+	// Split the combined data into nonce and ciphertext.
+	nonce := combined[:nonceSize]
+	ciphertext := combined[nonceSize:]
+
+	// Open the data.
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt or authenticate data: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/src/bottools/discord.go
+++ b/src/bottools/discord.go
@@ -1,0 +1,11 @@
+package bottools
+
+import "github.com/bwmarrin/discordgo"
+
+// GetInteractionUserID returns the user ID from an interaction, whether in a guild or DM
+func GetInteractionUserID(i *discordgo.InteractionCreate) string {
+	if i.GuildID == "" {
+		return i.User.ID
+	}
+	return i.Member.User.ID
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -47,6 +47,8 @@ var (
 	BannerURL string
 	// DevelopmentStaff is a list of user IDs for development staff.
 	DevelopmentStaff []string
+	// Key is the encryption key used for encrypting sensitive data.
+	Key string
 
 	config *configStruct
 )
@@ -72,6 +74,7 @@ type configStruct struct {
 	BannerOutputPath string   `json:"BannerOutputPath"`
 	BannerURL        string   `json:"BannerURL"`
 	DevelopmentStaff []string `json:"DevelopmentStaff"`
+	Key              string   `json:"Key"`
 }
 
 // ReadConfig will load the configuration files for API tokens.
@@ -112,6 +115,7 @@ func ReadConfig(cfgFile string) error {
 	BannerOutputPath = config.BannerOutputPath
 	BannerURL = config.BannerURL
 	DevelopmentStaff = config.DevelopmentStaff
+	Key = config.Key
 
 	return nil
 }

--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -2,10 +2,15 @@ package ei
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
@@ -88,24 +93,23 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	archive := backup.GetContracts().GetArchive()
 
 	// Want a function which will take an the archive parameter and print out the contractID, coopID, and cxp for each archived contract
-	printArchivedContracts(archive)
+	printArchivedContracts(archive, 20)
 }
 
 // GetContractArchiveFromAPI will download the events from the Egg Inc API
-func GetContractArchiveFromAPI(s *discordgo.Session) {
-	userID := config.EIUserIDBasic
+func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
 	reqURL := "https://www.auxbrain.com/ei_ctx/get_contracts_archive"
 	enc := base64.StdEncoding
 	clientVersion := uint32(99)
 
 	contractArchiveRequest := BasicRequestInfo{
-		EiUserId:      &userID,
+		EiUserId:      &eiUserID,
 		ClientVersion: &clientVersion,
 	}
 	reqBin, err := proto.Marshal(&contractArchiveRequest)
 	if err != nil {
 		log.Print(err)
-		return
+		return ""
 	}
 	values := url.Values{}
 	reqDataEncoded := enc.EncodeToString(reqBin)
@@ -114,7 +118,7 @@ func GetContractArchiveFromAPI(s *discordgo.Session) {
 	response, err := http.PostForm(reqURL, values)
 	if err != nil {
 		log.Print(err)
-		return
+		return ""
 	}
 
 	defer func() {
@@ -128,7 +132,7 @@ func GetContractArchiveFromAPI(s *discordgo.Session) {
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Print(err)
-		return
+		return ""
 	}
 
 	protoData := string(body)
@@ -138,40 +142,104 @@ func GetContractArchiveFromAPI(s *discordgo.Session) {
 	err = proto.Unmarshal(rawDecodedText, decodedAuthBuf)
 	if err != nil {
 		log.Print(err)
-		return
+		return ""
 	}
 
 	contractsArchiveResponse := &ContractsArchive{}
 	err = proto.Unmarshal(decodedAuthBuf.Message, contractsArchiveResponse)
 	if err != nil {
 		log.Print(err)
-		return
+		return ""
 	}
 
 	archive := contractsArchiveResponse.GetArchive()
 	if archive == nil {
 		log.Print("No archived contracts found in Egg Inc API response")
-		return
+		return ""
 	}
-	printArchivedContracts(archive)
+	return printArchivedContracts(archive, 20)
 }
 
-func printArchivedContracts(archive []*LocalContract) {
+func printArchivedContracts(archive []*LocalContract, percent int) string {
+	builder := strings.Builder{}
 	if archive == nil {
 		log.Print("No archived contracts found in Egg Inc API response")
-		return
+		return builder.String()
 	}
 	log.Printf("Downloaded %d archived contracts from Egg Inc API\n", len(archive))
+
+	// Want a preamble string for builder for what we're displaying
+	//builder.WriteString(fmt.Sprintf("## Displaying contract scores less than %d%% of speedrun potential:\n", percent))
+	builder.WriteString("## Contract CS eval of active contracts\n")
+	fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s`\n",
+		AlignString("CONTRACT-ID", 30, StringAlignCenter),
+		AlignString("CS", 6, StringAlignCenter),
+		AlignString("HIGH", 6, StringAlignCenter),
+		AlignString("GAP", 6, StringAlignRight),
+		AlignString("%", 4, StringAlignCenter),
+	)
+
 	for _, c := range archive {
 		contractID := c.GetContract().GetIdentifier()
-		coopID := c.GetCoopIdentifier()
+		//coopID := c.GetCoopIdentifier()
 		evaluation := c.GetEvaluation()
 		cxp := evaluation.GetCxp()
-		// Print the values of contractID, coopID, and cxp
-		log.Printf("Archived Contract ID: %s, Coop ID: %s, CXP: %f\n", contractID, coopID, cxp)
-		// You can also store these values in a data structure if needed
-		// For example, you could create a struct to hold this information
-		// and append it to a slice for later use.
+
+		c := EggIncContractsAll[contractID]
+		if c.ContractVersion == 2 && c.ExpirationTime.Unix() > time.Now().Unix() {
+			// Two ranges of estimates
+			// Speedrun w/ perfect set through to Sink with decent set
+			// Fair share from 1.05 to 0.92
+
+			//if cxp < c.Cxp*(1-float64(percent)/100) {
+
+			fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s` <t:%d:R>\n",
+				AlignString(contractID, 30, StringAlignLeft),
+				AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, StringAlignRight),
+				AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, StringAlignRight),
+				AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, StringAlignRight),
+				AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, StringAlignCenter),
+				c.ExpirationTime.Unix())
+			//}
+		}
 
 	}
+	return builder.String()
+}
+
+// StringAlign is an enum for string alignment
+type StringAlign int
+
+const (
+	// StringAlignLeft aligns the string to the left
+	StringAlignLeft StringAlign = iota
+	// StringAlignCenter aligns the string to the center
+	StringAlignCenter
+	// StringAlignRight aligns the string to the right
+	StringAlignRight
+)
+
+// AlignString aligns a string to the left, center, or right within a given width
+func AlignString(str string, width int, alignment StringAlign) string {
+	// Calculate the padding needed
+
+	padding := width - utf8.RuneCountInString(str)
+	if padding <= 0 {
+		return str
+	}
+
+	var leftPadding, rightPadding string
+	switch alignment {
+	case StringAlignLeft:
+		leftPadding = ""
+		rightPadding = strings.Repeat(" ", padding)
+	case StringAlignCenter:
+		leftPadding = strings.Repeat(" ", padding/2)
+		rightPadding = strings.Repeat(" ", padding-padding/2)
+	case StringAlignRight:
+		leftPadding = strings.Repeat(" ", padding)
+		rightPadding = ""
+	}
+
+	return leftPadding + str + rightPadding
 }

--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -180,6 +180,7 @@ type EggIncContract struct {
 	ContractVersion           int // 1 = old, 2 = new
 	Grade                     []ContractGrade
 	TeamNames                 []string // Names of the teams in the contract
+	Cxp                       float64  // CXP value for the contract
 }
 
 // EggIncContracts holds a list of all contracts, newest is last

--- a/src/ei/ei_units.go
+++ b/src/ei/ei_units.go
@@ -89,6 +89,7 @@ func ParseValueWithUnit(s string, unitRequired bool) (float64, error) {
 	return value * math.Pow10(oom), nil
 }
 
+// FormatEIValue formats a number in scientific notation with the given options.
 func FormatEIValue(x float64, options map[string]any) string {
 	trim := options["trim"] == true
 	decimals := 3

--- a/src/farmerstate/farmerstate.go
+++ b/src/farmerstate/farmerstate.go
@@ -340,10 +340,15 @@ func SetMiscSettingString(userID string, key string, value string) {
 	}
 
 	if !farmerstate[userID].DataPrivacy {
-		farmerstate[userID].LastUpdated = time.Now()
-		if farmerstate[userID].MiscSettingsString[key] != value {
-			farmerstate[userID].MiscSettingsString[key] = value
+		if value == "" {
+			delete(farmerstate[userID].MiscSettingsString, key)
 			saveData(farmerstate)
+		} else {
+			farmerstate[userID].LastUpdated = time.Now()
+			if farmerstate[userID].MiscSettingsString[key] != value {
+				farmerstate[userID].MiscSettingsString[key] = value
+				saveData(farmerstate)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit introduces two main changes:

1. Implement a new function `getContractScoreEstimate` to calculate the estimated contract score (CXP) for contracts with version 2. This function takes into account various factors such as the contract grade, booster usage, SIAB, Deflector, Chicken Runs, and token sending/receiving patterns to provide a more accurate CXP estimate.

2. Modify the `GetContractArchiveFromAPI` and `printArchivedContracts` functions to download and display the archived contracts from the Egg Inc API. The archived contracts are now displayed in a formatted table, showing the contract ID, estimated CXP, maximum potential CXP, the gap between the two, and the percentage of the maximum potential achieved.

These changes aim to provide more accurate CXP estimates for active contracts and better visibility into the performance of archived contracts, which can be useful for players to assess their progress and optimize their strategies.