### PR TITLE
feat: Refactor GetFirstContactFromAPI and GetContractArchiveFromAPI

### DIFF
--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -2,15 +2,10 @@ package ei
 
 import (
 	"encoding/base64"
-	"fmt"
 	"io"
 	"log"
-	"math"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
-	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
@@ -18,7 +13,7 @@ import (
 )
 
 // GetFirstContactFromAPI will download the events from the Egg Inc API
-func GetFirstContactFromAPI(s *discordgo.Session) {
+func GetFirstContactFromAPI(s *discordgo.Session) []*LocalContract {
 	userID := config.EIUserIDBasic
 	reqURL := "https://www.auxbrain.com//ei/bot_first_contact"
 	enc := base64.StdEncoding
@@ -46,7 +41,7 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	reqBin, err := proto.Marshal(&firstContactRequest)
 	if err != nil {
 		log.Print(err)
-		return
+		return nil
 	}
 	values := url.Values{}
 	reqDataEncoded := enc.EncodeToString(reqBin)
@@ -55,7 +50,7 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	response, err := http.PostForm(reqURL, values)
 	if err != nil {
 		log.Print(err)
-		return
+		return nil
 	}
 
 	defer func() {
@@ -69,7 +64,7 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Print(err)
-		return
+		return nil
 	}
 
 	protoData := string(body)
@@ -78,13 +73,13 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	err = proto.Unmarshal(rawDecodedText, firstContactResponse)
 	if err != nil {
 		log.Print(err)
-		return
+		return nil
 	}
 
 	backup := firstContactResponse.GetBackup()
 	if backup == nil {
 		log.Print("No backup found in Egg Inc API response")
-		return
+		return nil
 	}
 	PE := backup.GetGame().GetEggsOfProphecy()
 	SE := backup.GetGame().GetSoulEggsD()
@@ -93,11 +88,12 @@ func GetFirstContactFromAPI(s *discordgo.Session) {
 	archive := backup.GetContracts().GetArchive()
 
 	// Want a function which will take an the archive parameter and print out the contractID, coopID, and cxp for each archived contract
-	printArchivedContracts(archive, 20)
+	//printArchivedContracts(archive, 20)
+	return archive
 }
 
 // GetContractArchiveFromAPI will download the events from the Egg Inc API
-func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
+func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) []*LocalContract {
 	reqURL := "https://www.auxbrain.com/ei_ctx/get_contracts_archive"
 	enc := base64.StdEncoding
 	clientVersion := uint32(99)
@@ -109,7 +105,7 @@ func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
 	reqBin, err := proto.Marshal(&contractArchiveRequest)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return nil
 	}
 	values := url.Values{}
 	reqDataEncoded := enc.EncodeToString(reqBin)
@@ -118,7 +114,7 @@ func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
 	response, err := http.PostForm(reqURL, values)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return nil
 	}
 
 	defer func() {
@@ -132,7 +128,7 @@ func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return nil
 	}
 
 	protoData := string(body)
@@ -142,104 +138,20 @@ func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) string {
 	err = proto.Unmarshal(rawDecodedText, decodedAuthBuf)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return nil
 	}
 
 	contractsArchiveResponse := &ContractsArchive{}
 	err = proto.Unmarshal(decodedAuthBuf.Message, contractsArchiveResponse)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return nil
 	}
 
 	archive := contractsArchiveResponse.GetArchive()
 	if archive == nil {
 		log.Print("No archived contracts found in Egg Inc API response")
-		return ""
+		return nil
 	}
-	return printArchivedContracts(archive, 20)
-}
-
-func printArchivedContracts(archive []*LocalContract, percent int) string {
-	builder := strings.Builder{}
-	if archive == nil {
-		log.Print("No archived contracts found in Egg Inc API response")
-		return builder.String()
-	}
-	log.Printf("Downloaded %d archived contracts from Egg Inc API\n", len(archive))
-
-	// Want a preamble string for builder for what we're displaying
-	//builder.WriteString(fmt.Sprintf("## Displaying contract scores less than %d%% of speedrun potential:\n", percent))
-	builder.WriteString("## Contract CS eval of active contracts\n")
-	fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s`\n",
-		AlignString("CONTRACT-ID", 30, StringAlignCenter),
-		AlignString("CS", 6, StringAlignCenter),
-		AlignString("HIGH", 6, StringAlignCenter),
-		AlignString("GAP", 6, StringAlignRight),
-		AlignString("%", 4, StringAlignCenter),
-	)
-
-	for _, c := range archive {
-		contractID := c.GetContract().GetIdentifier()
-		//coopID := c.GetCoopIdentifier()
-		evaluation := c.GetEvaluation()
-		cxp := evaluation.GetCxp()
-
-		c := EggIncContractsAll[contractID]
-		if c.ContractVersion == 2 && c.ExpirationTime.Unix() > time.Now().Unix() {
-			// Two ranges of estimates
-			// Speedrun w/ perfect set through to Sink with decent set
-			// Fair share from 1.05 to 0.92
-
-			//if cxp < c.Cxp*(1-float64(percent)/100) {
-
-			fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s` <t:%d:R>\n",
-				AlignString(contractID, 30, StringAlignLeft),
-				AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, StringAlignRight),
-				AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, StringAlignRight),
-				AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, StringAlignRight),
-				AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, StringAlignCenter),
-				c.ExpirationTime.Unix())
-			//}
-		}
-
-	}
-	return builder.String()
-}
-
-// StringAlign is an enum for string alignment
-type StringAlign int
-
-const (
-	// StringAlignLeft aligns the string to the left
-	StringAlignLeft StringAlign = iota
-	// StringAlignCenter aligns the string to the center
-	StringAlignCenter
-	// StringAlignRight aligns the string to the right
-	StringAlignRight
-)
-
-// AlignString aligns a string to the left, center, or right within a given width
-func AlignString(str string, width int, alignment StringAlign) string {
-	// Calculate the padding needed
-
-	padding := width - utf8.RuneCountInString(str)
-	if padding <= 0 {
-		return str
-	}
-
-	var leftPadding, rightPadding string
-	switch alignment {
-	case StringAlignLeft:
-		leftPadding = ""
-		rightPadding = strings.Repeat(" ", padding)
-	case StringAlignCenter:
-		leftPadding = strings.Repeat(" ", padding/2)
-		rightPadding = strings.Repeat(" ", padding-padding/2)
-	case StringAlignRight:
-		leftPadding = strings.Repeat(" ", padding)
-		rightPadding = ""
-	}
-
-	return leftPadding + str + rightPadding
+	return archive
 }


### PR DESCRIPTION
The changes made in this commit are focused on refactoring the `GetFirstContactFromAPI` and `GetContractArchiveFromAPI` functions in the `ei_api.go` file. The main changes are:

1. The `GetFirstContactFromAPI` function now returns an array of `LocalContract` instead of printing the archived contracts directly. This allows the caller to handle the data as needed.
2. The `GetContractArchiveFromAPI` function also now returns an array of `LocalContract` instead of printing the archived contracts.
3. Unnecessary imports and code have been removed to keep the file more concise.

These changes make the functions more modular and easier to use in other parts of the application.