### PR TITLE
feat: Implement output truncation and contract count display

### DIFF
--- a/src/boost/replay.go
+++ b/src/boost/replay.go
@@ -191,12 +191,9 @@ func printArchivedContracts(archive []*ei.LocalContract, percent int) string {
 		bottools.AlignString("%", 4, bottools.StringAlignCenter),
 	)
 
-	for _, c := range archive {
+	count := 0
 
-		if builder.Len() > 3500 {
-			builder.WriteString("...output truncated...\n")
-			break
-		}
+	for _, c := range archive {
 
 		contractID := c.GetContract().GetIdentifier()
 		//coopID := c.GetCoopIdentifier()
@@ -207,25 +204,41 @@ func printArchivedContracts(archive []*ei.LocalContract, percent int) string {
 		//if c.ContractVersion == 2 {
 		if percent != -1 {
 			if cxp < c.Cxp*(1-float64(percent)/100) || c.Cxp == 0 {
-				fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s`\n",
-					bottools.AlignString(contractID, 30, bottools.StringAlignLeft),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, bottools.StringAlignCenter))
+				if builder.Len() < 3500 {
+					fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s`\n",
+						bottools.AlignString(contractID, 30, bottools.StringAlignLeft),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, bottools.StringAlignCenter))
+				}
+				count++
 			}
 		} else {
 			if c.ContractVersion == 2 && c.ExpirationTime.Unix() > time.Now().Unix() {
-				fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s` <t:%d:R>\n",
-					bottools.AlignString(contractID, 30, bottools.StringAlignLeft),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, bottools.StringAlignRight),
-					bottools.AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, bottools.StringAlignCenter),
-					c.ExpirationTime.Unix())
+				if builder.Len() < 3500 {
+					fmt.Fprintf(&builder, "`%12s %6s %6s %6s %6s` <t:%d:R>\n",
+						bottools.AlignString(contractID, 30, bottools.StringAlignLeft),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%d", int(math.Ceil(c.Cxp-cxp))), 6, bottools.StringAlignRight),
+						bottools.AlignString(fmt.Sprintf("%.1f", (cxp/c.Cxp)*100), 4, bottools.StringAlignCenter),
+						c.ExpirationTime.Unix())
+				}
+				count++
 			}
 		}
 		//}
+	}
+	if builder.Len() > 3500 {
+		builder.WriteString("...output truncated...\n")
+	}
+	if percent != -1 {
+		builder.WriteString(fmt.Sprintf("%d of %d contracts met this condition.\n", count, len(archive)))
+	}
+	if count == 0 {
+		builder.Reset()
+		builder.WriteString("No contracts met this condition.\n")
 	}
 	return builder.String()
 }


### PR DESCRIPTION
This change introduces two key improvements to the replay functionality:

1. Output truncation: The code now limits the output to 3500 characters, adding an "...output truncated..." message if the output exceeds this limit.

2. Contract count display: When a percentage filter is applied, the code now displays the number of contracts that meet the condition, as well as a message indicating that no contracts met the condition if the count is zero.

These changes enhance the user experience by providing more informative and concise output, especially when dealing with large contract archives.