### PR TITLE
feat(ei_api): Implement caching and encryption for Egg Inc API requests

### DIFF
--- a/src/config/encryption.go
+++ b/src/config/encryption.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// The size of the AES key. 32 bytes for AES-256.
+const keySize = 32
+
+// GenerateKey creates a new, random 32-byte key for AES-256.
+func GenerateKey() ([]byte, error) {
+	key := make([]byte, keySize)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate key: %w", err)
+	}
+	return key, nil
+}
+
+// EncryptAndCombine performs AES-GCM encryption and returns the
+// nonce and ciphertext combined into a single byte slice.
+func EncryptAndCombine(key []byte, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM instance: %w", err)
+	}
+
+	// Create a new, unique nonce.
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Seal the plaintext, which returns the ciphertext.
+	ciphertext := aesgcm.Seal(nil, nonce, plaintext, nil)
+
+	// Prepend the nonce to the ciphertext.
+	combined := append(nonce, ciphertext...)
+
+	return combined, nil
+}
+
+// DecryptCombined performs AES-GCM decryption on a combined byte slice.
+// It splits the nonce from the ciphertext and then decrypts the data.
+func DecryptCombined(key []byte, combined []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM instance: %w", err)
+	}
+
+	nonceSize := aesgcm.NonceSize()
+	if len(combined) < nonceSize {
+		return nil, fmt.Errorf("invalid combined data: too short to contain nonce")
+	}
+
+	// Split the combined data into nonce and ciphertext.
+	nonce := combined[:nonceSize]
+	ciphertext := combined[nonceSize:]
+
+	// Open the data.
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt or authenticate data: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
@@ -13,64 +15,97 @@ import (
 )
 
 // GetFirstContactFromAPI will download the events from the Egg Inc API
-func GetFirstContactFromAPI(s *discordgo.Session) []*LocalContract {
-	userID := config.EIUserIDBasic
+func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID string) []*LocalContract {
 	reqURL := "https://www.auxbrain.com//ei/bot_first_contact"
 	enc := base64.StdEncoding
-	clientVersion := uint32(68)
 
-	platform := Platform_IOS
-	platformString := "IOS"
-	version := "1.34.1"
-	build := "111300"
-
-	firstContactRequest := EggIncFirstContactRequest{
-		Rinfo: &BasicRequestInfo{
-			EiUserId:      &userID,
-			ClientVersion: &clientVersion,
-			Version:       &version,
-			Build:         &build,
-			Platform:      &platformString,
-		},
-		EiUserId:      &userID,
-		DeviceId:      proto.String("BoostBot"),
-		ClientVersion: &clientVersion,
-		Platform:      &platform,
-	}
-
-	reqBin, err := proto.Marshal(&firstContactRequest)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-	values := url.Values{}
-	reqDataEncoded := enc.EncodeToString(reqBin)
-	values.Set("data", string(reqDataEncoded))
-
-	response, err := http.PostForm(reqURL, values)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-
-	defer func() {
-		if err := response.Body.Close(); err != nil {
-			// Handle the error appropriately, e.g., logging or taking corrective actions
-			log.Printf("Failed to close: %v", err)
+	protoData := ""
+	if fileInfo, err := os.Stat("ttbb-data/eiuserdata/firstcontact-" + discordID + ".pb"); err == nil {
+		// File exists, check if it's within 10 minutes
+		if time.Since(fileInfo.ModTime()) <= 10*time.Minute {
+			// File is recent, load it
+			data, err := os.ReadFile("ttbb-data/eiuserdata/firstcontact-" + discordID + ".pb")
+			if err == nil {
+				encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+				if err == nil {
+					decryptedData, err := config.DecryptCombined(encryptionKey, []byte(data))
+					if err == nil {
+						protoData = string(decryptedData)
+						// Successfully decrypted, use protoData
+					}
+				}
+			}
 		}
-	}()
-
-	// Read the response body
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		log.Print(err)
-		return nil
 	}
 
-	protoData := string(body)
+	if protoData == "" {
+		clientVersion := uint32(68)
+
+		platform := Platform_IOS
+		platformString := "IOS"
+		version := "1.34.1"
+		build := "111300"
+
+		firstContactRequest := EggIncFirstContactRequest{
+			Rinfo: &BasicRequestInfo{
+				EiUserId:      &eiUserID,
+				ClientVersion: &clientVersion,
+				Version:       &version,
+				Build:         &build,
+				Platform:      &platformString,
+			},
+			EiUserId:      &eiUserID,
+			DeviceId:      proto.String("BoostBot"),
+			ClientVersion: &clientVersion,
+			Platform:      &platform,
+		}
+
+		reqBin, err := proto.Marshal(&firstContactRequest)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+		values := url.Values{}
+		reqDataEncoded := enc.EncodeToString(reqBin)
+		values.Set("data", string(reqDataEncoded))
+
+		response, err := http.PostForm(reqURL, values)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+
+		defer func() {
+			if err := response.Body.Close(); err != nil {
+				// Handle the error appropriately, e.g., logging or taking corrective actions
+				log.Printf("Failed to close: %v", err)
+			}
+		}()
+
+		// Read the response body
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+		protoData = string(body)
+
+		encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+		if err == nil {
+			combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+			if err == nil {
+				_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
+				err = os.WriteFile("ttbb-data/eiuserdata/firstcontact-"+discordID+".pb", []byte(combinedData), 0644)
+				if err != nil {
+					log.Print(err)
+				}
+			}
+		}
+	}
+
 	rawDecodedText, _ := enc.DecodeString(protoData)
 	firstContactResponse := &EggIncFirstContactResponse{}
-	err = proto.Unmarshal(rawDecodedText, firstContactResponse)
+	err := proto.Unmarshal(rawDecodedText, firstContactResponse)
 	if err != nil {
 		log.Print(err)
 		return nil
@@ -93,49 +128,84 @@ func GetFirstContactFromAPI(s *discordgo.Session) []*LocalContract {
 }
 
 // GetContractArchiveFromAPI will download the events from the Egg Inc API
-func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string) []*LocalContract {
+func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string, discordID string) []*LocalContract {
 	reqURL := "https://www.auxbrain.com/ei_ctx/get_contracts_archive"
 	enc := base64.StdEncoding
 	clientVersion := uint32(99)
+	protoData := ""
 
-	contractArchiveRequest := BasicRequestInfo{
-		EiUserId:      &eiUserID,
-		ClientVersion: &clientVersion,
-	}
-	reqBin, err := proto.Marshal(&contractArchiveRequest)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-	values := url.Values{}
-	reqDataEncoded := enc.EncodeToString(reqBin)
-	values.Set("data", string(reqDataEncoded))
-
-	response, err := http.PostForm(reqURL, values)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-
-	defer func() {
-		if err := response.Body.Close(); err != nil {
-			// Handle the error appropriately, e.g., logging or taking corrective actions
-			log.Printf("Failed to close: %v", err)
+	if fileInfo, err := os.Stat("ttbb-data/eiuserdata/archive-" + discordID + ".pb"); err == nil {
+		// File exists, check if it's within 10 minutes
+		if time.Since(fileInfo.ModTime()) <= 10*time.Minute {
+			// File is recent, load it
+			data, err := os.ReadFile("ttbb-data/eiuserdata/archive-" + discordID + ".pb")
+			if err == nil {
+				encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+				if err == nil {
+					decryptedData, err := config.DecryptCombined(encryptionKey, []byte(data))
+					if err == nil {
+						protoData = string(decryptedData)
+						// Successfully decrypted, use protoData
+					}
+				}
+			}
 		}
-	}()
-
-	// Read the response body
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		log.Print(err)
-		return nil
 	}
 
-	protoData := string(body)
+	if protoData == "" {
+
+		contractArchiveRequest := BasicRequestInfo{
+			EiUserId:      &eiUserID,
+			ClientVersion: &clientVersion,
+		}
+		reqBin, err := proto.Marshal(&contractArchiveRequest)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+		values := url.Values{}
+		reqDataEncoded := enc.EncodeToString(reqBin)
+		values.Set("data", string(reqDataEncoded))
+
+		response, err := http.PostForm(reqURL, values)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+
+		defer func() {
+			if err := response.Body.Close(); err != nil {
+				// Handle the error appropriately, e.g., logging or taking corrective actions
+				log.Printf("Failed to close: %v", err)
+			}
+		}()
+
+		// Read the response body
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Print(err)
+			return nil
+		}
+
+		protoData = string(body)
+
+		// Encrypt this to save to disk
+		encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+		if err == nil {
+			combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+			if err == nil {
+				_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
+				err = os.WriteFile("ttbb-data/eiuserdata/archive-"+discordID+".pb", []byte(combinedData), 0644)
+				if err != nil {
+					log.Print(err)
+				}
+			}
+		}
+	}
 
 	decodedAuthBuf := &AuthenticatedMessage{}
 	rawDecodedText, _ := enc.DecodeString(protoData)
-	err = proto.Unmarshal(rawDecodedText, decodedAuthBuf)
+	err := proto.Unmarshal(rawDecodedText, decodedAuthBuf)
 	if err != nil {
 		log.Print(err)
 		return nil


### PR DESCRIPTION
This commit introduces several improvements to the `GetFirstContactFromAPI` and `GetContractArchiveFromAPI` functions:

1. Caching: The function now checks if a cached file exists for the given Discord ID. If the file is within 10 minutes old, it loads the data from the cache instead of making a new API request.

2. Encryption: The cached data is encrypted using the encryption key from the `config` package. This ensures that the sensitive Egg Inc user data is stored securely on the file system.

3. Fallback to API request: If no cached data is available or the cached data is too old, the function falls back to making a new API request and saves the response to the cache.

These changes improve the performance and security of the bot by reducing the number of API requests and protecting user data.