### PR TITLE
feat: Rename "m_m_eggid" command to "m_eggid"

### DIFF
--- a/main.go
+++ b/main.go
@@ -767,7 +767,7 @@ var (
 		"fd_signupBell": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			joinContract(s, i, true)
 		},
-		"m_m_eggid": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		"m_eggid": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleEggIDModalSubmit(s, i)
 		},
 		"fd_signupLeave": func(s *discordgo.Session, i *discordgo.InteractionCreate) {


### PR DESCRIPTION
The "m_m_eggid" command has been renamed to "m_eggid" to simplify the
command naming convention. This change will make the codebase more
maintainable and easier to understand.