### PR TITLE
feat: Disable Go telemetry in build workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         mkdir -p output/{linux,freebsd}
         VERSION=$(git describe --tags)
+        go telemetry off
         CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64  go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/freebsd/boostbot-$VERSION-freebsd-amd64
         CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/linux/boostbot-$VERSION-linux-arm
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/linux/boostbot-$VERSION-linux-amd64


### PR DESCRIPTION
Disable the Go telemetry feature in the development build workflow to
reduce the amount of data sent to the Go team. This change ensures that
the build process is more privacy-focused and reduces the potential
impact on user privacy.