### PR TITLE
feat: Build binaries for FreeBSD and Linux

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -26,9 +26,7 @@ jobs:
       run: |
         mkdir -p output/{linux,freebsd}
         VERSION=$(git describe --tags)
-        go telemetry off
         CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64  go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/freebsd/boostbot-$VERSION-freebsd-amd64
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/linux/boostbot-$VERSION-linux-arm
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -ldflags "-s -X github.com/mkmccarty/TokenTimeBoostBot/version.GitHash=$(git describe --tags --always --long --dirty)" -o output/linux/boostbot-$VERSION-linux-amd64
     - name: Upload linux
       if: startsWith(matrix.go-version,'1.25.1')


### PR DESCRIPTION
Builds binaries for FreeBSD and Linux platforms, including amd64 and arm
architectures. Removes the `go telemetry off` command as it is no longer
necessary.