### PR TITLE
feat(eggidmodal): Add option to save or forget Egg Inc ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mkmccarty/TokenTimeBoostBot
 go 1.25.1
 
 require (
-	github.com/bwmarrin/discordgo v0.29.0
+	github.com/bwmarrin/discordgo v0.29.1-0.20250831103706-30fe1930ba2c
 	github.com/divan/num2words v1.0.3
 	github.com/ewohltman/discordgo-mock v0.0.11
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.8.0 h1:HxMRIbao8w17ZX6wBnjhcDkW6lTFpgcao
 cloud.google.com/go/compute/metadata v0.8.0/go.mod h1:sYOGTp851OV9bOFJ9CH7elVvyzopvWQFNNghtDQ/Biw=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.29.1-0.20250831103706-30fe1930ba2c h1:MHFIaN//8vT40sVX80TkBYTPDxj+BLVhbPe4+CfYTPY=
+github.com/bwmarrin/discordgo v0.29.1-0.20250831103706-30fe1930ba2c/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetFirstContactFromAPI will download the player data from the Egg Inc API
-func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID string) (*Backup, bool) {
+func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID string, okayToSave bool) (*Backup, bool) {
 	reqURL := "https://www.auxbrain.com//ei/bot_first_contact"
 	enc := base64.StdEncoding
 	cachedData := false
@@ -93,14 +93,16 @@ func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID str
 		}
 		protoData = string(body)
 
-		encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
-		if err == nil {
-			combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+		if okayToSave {
+			encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
 			if err == nil {
-				_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
-				err = os.WriteFile("ttbb-data/eiuserdata/firstcontact-"+discordID+".pb", []byte(combinedData), 0644)
-				if err != nil {
-					log.Print(err)
+				combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+				if err == nil {
+					_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
+					err = os.WriteFile("ttbb-data/eiuserdata/firstcontact-"+discordID+".pb", []byte(combinedData), 0644)
+					if err != nil {
+						log.Print(err)
+					}
 				}
 			}
 		}
@@ -139,7 +141,7 @@ func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID str
 }
 
 // GetContractArchiveFromAPI will download the events from the Egg Inc API
-func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string, discordID string) ([]*LocalContract, bool) {
+func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string, discordID string, okayToSave bool) ([]*LocalContract, bool) {
 	reqURL := "https://www.auxbrain.com/ei_ctx/get_contracts_archive"
 	enc := base64.StdEncoding
 	clientVersion := uint32(99)
@@ -203,14 +205,16 @@ func GetContractArchiveFromAPI(s *discordgo.Session, eiUserID string, discordID 
 		protoData = string(body)
 
 		// Encrypt this to save to disk
-		encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
-		if err == nil {
-			combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+		if okayToSave {
+			encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
 			if err == nil {
-				_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
-				err = os.WriteFile("ttbb-data/eiuserdata/archive-"+discordID+".pb", []byte(combinedData), 0644)
-				if err != nil {
-					log.Print(err)
+				combinedData, err := config.EncryptAndCombine(encryptionKey, []byte(protoData))
+				if err == nil {
+					_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
+					err = os.WriteFile("ttbb-data/eiuserdata/archive-"+discordID+".pb", []byte(combinedData), 0644)
+					if err != nil {
+						log.Print(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This commit adds a new text input field to the Egg Inc ID modal, allowing the user to choose whether to save or forget their Egg Inc ID after the current session. The changes include:

- Added a new text input field with the custom ID "confirm" to the modal, allowing the user to choose "save" or "forget" their Egg Inc ID.
- Updated the `HandleEggIDModalSubmit` function to handle the "confirm" input and set the appropriate flag for saving or forgetting the Egg Inc ID.
- Passed the "save" flag to the `GetFirstContactFromAPI` function to determine whether to save the Egg Inc ID for future sessions.
- Provided feedback to the user in the modal response, indicating whether their Egg Inc ID will be saved or forgotten.

This change improves the user experience by giving them more control over the management of their Egg Inc ID, allowing them to choose whether to save it for future use or forget it after the current session.