### PR TITLE
feat: Save user data to file if not cached and okay to save

### DIFF
--- a/src/boost/replay.go
+++ b/src/boost/replay.go
@@ -146,7 +146,7 @@ func ReplayEval(s *discordgo.Session, i *discordgo.InteractionCreate, percent in
 		},
 	})
 
-	if !cached {
+	if !cached && okayToSave {
 		discordID := userID
 		fileName := fmt.Sprintf("ttbb-data/eiuserdata/archive-%s-%s.json", discordID, cxpVersion)
 		// Replace eggIncID with userID in the JSON data


### PR DESCRIPTION
Adds a check to save user data to a file if the data is not cached and it
is okay to save the data. This ensures that user data is persisted to
disk for later retrieval.