### PR TITLE
feat(bottools): add player data and data gathering functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mkmccarty/TokenTimeBoostBot/src/boost"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
-	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/events"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/notok"
@@ -83,6 +82,7 @@ const slashScoreExplorer string = "score-explorer"
 const slashRemoveDMMessage string = "remove-dm-message"
 const slashPrivacy string = "privacy"
 const slashRerunEval string = "rerun-eval"
+const slashVirtue string = "virtue"
 
 var integerZeroMinValue float64 = 0.0
 
@@ -179,6 +179,7 @@ var (
 		track.GetSlashTokenCommand(slashToken),
 		track.GetSlashTokenEditTrackCommand(slashTokenEditTrack),
 		boost.GetSlashReplayEvalCommand(slashRerunEval),
+		boost.GetSlashVirtueCommand(slashVirtue),
 	}
 
 	commands = []*discordgo.ApplicationCommand{
@@ -494,6 +495,9 @@ var (
 		},
 		slashRerunEval: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleReplayEval(s, i)
+		},
+		slashVirtue: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			boost.HandleVirtue(s, i)
 		},
 		slashToken: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boost.HandleTokenCommand(s, i)

--- a/src/boost/eggidmodal.go
+++ b/src/boost/eggidmodal.go
@@ -97,10 +97,23 @@ func HandleEggIDModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate
 
 		percent, err := strconv.Atoi(parts[2])
 		if err != nil {
-			str = "Invalid ID provided."
+			str = "Invalid percent provided."
 			break
 		}
 		ReplayEval(s, i, percent, encryptedID, okayToSave)
+		return
+	case "virtue":
+		if encryptedID == "" {
+			str = "You must provide a valid Egg Inc ID to proceed."
+			break
+		}
+
+		percent, err := strconv.Atoi(parts[2])
+		if err != nil {
+			str = "Invalid ID provided."
+			break
+		}
+		Virtue(s, i, percent, encryptedID, okayToSave)
 		return
 	default:
 	}

--- a/src/boost/replay.go
+++ b/src/boost/replay.go
@@ -233,3 +233,37 @@ func printArchivedContracts(archive []*ei.LocalContract, percent int) string {
 	}
 	return builder.String()
 }
+
+/*
+{
+	"evaluation": {
+		"contract_identifier": "birthday-cake-2023",
+		"coop_identifier": "happy-token",
+		"cxp": 24702,
+		"old_league": 0,
+		"grade": 0,
+		"contribution_ratio": 5.815095492301126,
+		"completion_percent": 1,
+		"original_length": 432000,
+		"coop_size": 10,
+		"solo": false,
+		"soul_power": 30.02439174202951,
+		"last_contribution_time": 1680055626.437586,
+		"completion_time": 91932.26965808868,
+		"chicken_runs_sent": 5,
+		"gift_tokens_sent": 7,
+		"gift_tokens_received": 0,
+		"gift_token_value_sent": 0.7000000000000001,
+		"gift_token_value_received": 0,
+		"boost_token_allotment": 25,
+		"buff_time_value": 38309.730632150175,
+		"teamwork_score": 0.31141672867206993,
+		"counted_in_season": false,
+		"season_id": "",
+		"time_cheats": 0,
+		"version": "cxp-v0.2.0",
+		"evaluation_start_time": 1696778185.855627,
+		"status": 3
+	}
+}
+*/

--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -1,0 +1,132 @@
+package boost
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/farmerstate"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// GetSlashVirtueCommand returns the command for the /launch-helper command
+func GetSlashVirtueCommand(cmd string) *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        cmd,
+		Description: "Evaluate contract history and provide replay guidance.",
+		Contexts: &[]discordgo.InteractionContextType{
+			discordgo.InteractionContextGuild,
+			discordgo.InteractionContextBotDM,
+			discordgo.InteractionContextPrivateChannel,
+		},
+		IntegrationTypes: &[]discordgo.ApplicationIntegrationType{
+			discordgo.ApplicationIntegrationGuildInstall,
+			discordgo.ApplicationIntegrationUserInstall,
+		},
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "reset",
+				Description: "Reset stored EI number",
+				Required:    false,
+			},
+		},
+	}
+}
+
+// HandleVirtue handles the /virtue command
+func HandleVirtue(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	userID := bottools.GetInteractionUserID(i)
+	percent := -1
+
+	options := i.ApplicationCommandData().Options
+	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
+	for _, opt := range options {
+		optionMap[opt.Name] = opt
+	}
+
+	if opt, ok := optionMap["reset"]; ok {
+		if opt.BoolValue() {
+			farmerstate.SetMiscSettingString(userID, "encrypted_ei_id", "")
+		}
+	}
+
+	eiID := farmerstate.GetMiscSettingString(userID, "encrypted_ei_id")
+
+	Virtue(s, i, percent, eiID, true)
+}
+
+// Virtue processes the virtue command
+func Virtue(s *discordgo.Session, i *discordgo.InteractionCreate, percent int, eiID string, okayToSave bool) {
+	// Get the Egg Inc ID from the stored settings
+	eggIncID := ""
+	encryptionKey, err := base64.StdEncoding.DecodeString(config.Key)
+	if err == nil {
+		decodedData, err := base64.StdEncoding.DecodeString(eiID)
+		if err == nil {
+			decryptedData, err := config.DecryptCombined(encryptionKey, decodedData)
+			if err == nil {
+				eggIncID = string(decryptedData)
+			}
+		}
+	}
+	if eggIncID == "" || len(eggIncID) != 18 || eggIncID[:2] != "EI" {
+		RequestEggIncIDModal(s, i, fmt.Sprintf("virtue#%d", 0))
+		return
+	}
+
+	// Quick reply to buy us some time
+	flags := discordgo.MessageFlagsIsComponentsV2
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "Processing request...",
+			Flags:   flags,
+		},
+	})
+
+	userID := bottools.GetInteractionUserID(i)
+
+	backup, _ := ei.GetFirstContactFromAPI(s, eggIncID, userID, okayToSave)
+
+	virtue := backup.GetVirtue()
+	str := printVirtue(virtue)
+	if str == "" {
+		str = "No archived contracts found in Egg Inc API response"
+	}
+	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Flags: flags,
+		Components: []discordgo.MessageComponent{
+			discordgo.TextDisplay{Content: str},
+		},
+	})
+
+}
+
+func printVirtue(virtue *ei.Backup_Virtue) string {
+	builder := strings.Builder{}
+	if virtue == nil {
+		log.Print("No virtue backup data found in Egg Inc API response")
+		return builder.String()
+	}
+
+	fmt.Fprintf(&builder, "# Eggs Of Virtue\n")
+	fmt.Fprintf(&builder, "Shift Count: %d\n", virtue.GetShiftCount())
+	fmt.Fprintf(&builder, "Resets: %d\n", virtue.GetResets())
+	fmt.Fprintf(&builder, "Inventory Score %.0f\n", virtue.GetAfx().GetInventoryScore())
+
+	virtueEggs := []string{"CURIOSITY", "INTEGRITY", "HUMILITY", "RESILIENCE", "KINDNESS"}
+
+	for i, egg := range virtueEggs {
+		eov := virtue.GetEovEarned()[i] // Assuming Eggs is the correct field for accessing egg virtues
+		delivered := virtue.GetEggsDelivered()[i]
+		fmt.Fprintf(&builder, "%s %d: %.0f\n", ei.GetBotEmojiMarkdown("egg_"+strings.ToLower(egg)), eov, delivered)
+	}
+
+	return builder.String()
+}

--- a/src/bottools/staabmia_link.go
+++ b/src/bottools/staabmia_link.go
@@ -286,3 +286,119 @@ func GetStaabmiaLink(darkMode bool, modifierType ei.GameModifier_GameDimension, 
 
 	return link + version + base64encoded + "=" + base62encoded
 }
+
+type PlayerData struct {
+	Name                 string
+	Tokens               string
+	PlayerMirror         bool
+	ShippingColleggtible bool
+	Sink                 bool
+	Creator              bool
+	Items                []int // Assuming items are represented as indices
+}
+
+type InputData struct {
+	CrtToggle       bool
+	TokenToggle     bool
+	GGToggle        bool
+	EggUnitIndex    int
+	DurUnitIndex    int
+	ModNameIndex    int
+	CrtTime         string
+	Mpft            string
+	Duration        string
+	TargetEggAmount string
+	TokenTimer      string
+	Modifiers       string
+	NumPlayers      int
+	BtvTarget       string
+	Players         []PlayerData
+}
+
+func gatherData(input InputData) (string, string) {
+	separator := "-" // Unique separator character
+	data := []string{}
+	singleStr := []string{}
+	data2 := []string{}
+
+	singleStr = append(singleStr, boolToString(input.CrtToggle))
+	singleStr = append(singleStr, boolToString(input.TokenToggle))
+	singleStr = append(singleStr, boolToString(input.GGToggle))
+	singleStr = append(singleStr, strconv.Itoa(input.EggUnitIndex))
+	singleStr = append(singleStr, strconv.Itoa(input.DurUnitIndex))
+	singleStr = append(singleStr, strconv.Itoa(input.ModNameIndex))
+	data = append(data, strings.Join(singleStr, ""))
+
+	data = append(data, convertString(input.CrtTime))
+	data = append(data, convertString(input.Mpft))
+	data = append(data, convertString(input.Duration))
+	data = append(data, convertString(input.TargetEggAmount))
+	data = append(data, convertString(input.TokenTimer))
+	data = append(data, convertString(input.Modifiers))
+	data = append(data, strconv.Itoa(input.NumPlayers))
+	data = append(data, convertString(input.BtvTarget))
+
+	singleStr2 := []string{"1"} // Start with leading 1 to avoid losing leading 0's
+
+	for _, player := range input.Players {
+		singleStr2 = append(singleStr2, remDash(player.Name))
+		singleStr2 = append(singleStr2, remDash(player.Tokens))
+		singleStr2 = append(singleStr2, boolToString(player.PlayerMirror))
+		singleStr2 = append(singleStr2, boolToString(player.ShippingColleggtible))
+		singleStr2 = append(singleStr2, boolToString(player.Sink))
+		singleStr2 = append(singleStr2, boolToString(player.Creator))
+
+		for _, item := range player.Items {
+			singleStr2 = append(singleStr2, fmt.Sprintf("%02d", item))
+		}
+	}
+
+	// Break into chunks of 16
+	data2 = append(data2, chunk16(strings.Join(singleStr2, "")))
+
+	//y = x.toString(36);
+	//data2.push(y);
+
+	// Join all data into a single string separated by the unique separator
+	return strings.Join(data, separator), strings.Join(data2, separator)
+}
+
+func boolToString(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func convertString(data string) string {
+	return strings.ReplaceAll(data, ".", "p")
+}
+
+func remDash(data string) string {
+	return strings.ReplaceAll(data, "-", "axJEFi")
+}
+
+/*
+
+Do you mean the data= field? The source code is here for sandbox .
+You can try to figure out the loadDataFromUrl(), gatherdata() and populatedata()
+functions if you want. Alternatively, you could fork it
+(You should be able to grab the html and css files from inspect) and do what you please,
+or recommend code changes.
+
+https://srsandbox-staabmia.netlify.app/scripts.js
+
+
+v-3
+MTEwMDAwLTUtMTMtNy01MDAtNjAtMS0xLTItUGxheWVyJTIwMC02=B6mEavjeExzag
+
+
+MTEwMDAwLTUtMTMtNy01MDAtNjAtMS0xLTItUGxheWVyJTIwMC02=
+B6mEavjeExzag
+
+datap = 110000-5-13-7-500-60-1-1-2-Player%200-6
+data2p = B6mEavjeExzag
+
+
+
+*/

--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -133,10 +133,6 @@ func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID str
 		}
 	}
 
-	PE := backup.GetGame().GetEggsOfProphecy()
-	SE := backup.GetGame().GetSoulEggsD()
-	log.Printf("%s  \nPE:%v \nSE:%s\n", backup.GetUserName(), PE, FormatEIValue(SE, map[string]any{"decimals": 3, "trim": true}))
-
 	return backup, cachedData
 }
 


### PR DESCRIPTION
This commit adds a new `PlayerData` struct and `gatherData` function to the `bottools` package. The `PlayerData` struct represents player-specific data, including their name, tokens, and various boolean flags. The `gatherData` function takes an `InputData` struct and generates two strings, `data` and `data2`, which represent the serialized form of the input data.

The main changes in this commit are:

1. Added `PlayerData` struct to represent player-specific data.
2. Implemented the `gatherData` function to serialize the input data into two strings, `data` and `data2`.
3. Added helper functions `boolToString`, `convertString`, and `remDash` to assist with data conversion and formatting.

These changes are important as they provide the necessary functionality to handle and serialize player data, which is a key requirement for the bot's functionality.