### PR TITLE
feat(virtue): Optimize EOV calculation

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -197,7 +197,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 		}
 
 		allEov += eov
-		futureEov += max(uint32(eovPending)-uint32(eov), 0)
+		futureEov += uint32(eovPending) - max(uint32(eov), 0)
 
 		fmt.Fprintf(&vebuilder, "%s%s %d (%d)  |  🥚: %s |  %s at %s%s\n",
 			ei.GetBotEmojiMarkdown("egg_"+strings.ToLower(egg)),


### PR DESCRIPTION
Optimize the calculation of `futureEov` by using a more efficient
subtraction operation instead of the previous `max()` function. This
change ensures that the `futureEov` value is correctly updated based on
the difference between `eovPending` and `eov`.