### PR TITLE
feat(estimate_time): Improve target TVal display for CXP v1 contracts

### DIFF
--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -102,7 +102,7 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 	c.Ultra = contractProtoBuf.GetCcOnly()
 	c.SeasonID = contractProtoBuf.GetSeasonId()
 
-	if c.SeasonID == "fall_2025" || c.SeasonID == "winter_2025" || strings.Contains(c.SeasonID, "2026") {
+	if c.SeasonID == "fall_2025" || strings.Contains(c.SeasonID, "2026") {
 		c.CxpVersion = 1
 	}
 
@@ -217,6 +217,9 @@ func PopulateContractFromProto(contractProtoBuf *ei.Contract) ei.EggIncContract 
 		days := d.Hours() / 24.0 // 2 days
 		c.ContractDurationInDays = int(days)
 		c.ChickenRuns = int(min(20.0, math.Ceil((days*float64(c.MaxCoopSize))/2.0)))
+		if c.CxpVersion == 1 {
+			c.ChickenRuns = c.MaxCoopSize - 1
+		}
 	}
 	// Duration estimate
 	if len(c.TargetAmount) != 0 {

--- a/src/boost/estimate_time.go
+++ b/src/boost/estimate_time.go
@@ -212,11 +212,13 @@ func getContractEstimateString(contractID string) string {
 
 		str += fmt.Sprintf("CS Est: **%d** (SR) - **%d** (Sink) - **%d** (Best Effort)\n", scoreBest, scoreBestSink, scoreBestEffort)
 
-		if math.Round(c.TargetTval*100)/100 == math.Round(c.TargetTvalLower*100)/100 {
-			str += fmt.Sprintf("Target TVal: **%.2f**\n", c.TargetTval)
-		} else {
-			str += fmt.Sprintf("Target TVal: **%.2f** for lower estimate\n", c.TargetTvalLower)
-			str += fmt.Sprintf("Target TVal: **%.2f** for upper estimate\n", c.TargetTval)
+		if c.CxpVersion != 1 {
+			if math.Round(c.TargetTval*100)/100 == math.Round(c.TargetTvalLower*100)/100 {
+				str += fmt.Sprintf("Target TVal: **%.2f**\n", c.TargetTval)
+			} else {
+				str += fmt.Sprintf("Target TVal: **%.2f** for lower estimate\n", c.TargetTvalLower)
+				str += fmt.Sprintf("Target TVal: **%.2f** for upper estimate\n", c.TargetTval)
+			}
 		}
 	}
 


### PR DESCRIPTION
Modify the target TVal display logic to handle CXP v1 contracts differently.
For CXP v1 contracts, only display the single target TVal value, regardless
of whether the lower and upper estimates are the same.

feat(boost_import): Adjust chicken run calculation for CXP v1 contracts

Update the chicken run calculation to set the number of chicken runs to the
max coop size minus 1 for CXP v1 contracts. This change ensures that the
chicken run count is correctly calculated for these older contract versions.