### PR TITLE
feat(contracts): Adjust CR cap for CxpVersion 1 contracts

### DIFF
--- a/src/boost/siab.go
+++ b/src/boost/siab.go
@@ -811,6 +811,10 @@ func DownloadCoopStatusSiab(contractID string, coopID string, offsetEndTime time
 				contractDurationSeconds,
 				0, 0, 0)
 			capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
+			if eiContract.CxpVersion == 1 {
+				capCR = eiContract.MaxCoopSize - 1
+			}
+
 			diffCR := (float64(scoreBase) * 0.06) / float64(capCR)
 
 			var crBuilder strings.Builder
@@ -838,6 +842,10 @@ func DownloadCoopStatusSiab(contractID string, coopID string, offsetEndTime time
 		}
 		// Create a table of Contract Scores for this user
 		capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
+		if eiContract.CxpVersion == 1 {
+			capCR = eiContract.MaxCoopSize - 1
+		}
+
 		var csBuilder strings.Builder
 
 		// Maximum Contract Score with current buffs and max CR & TVAL

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -819,6 +819,10 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 				contractDurationSeconds,
 				0, 0, 0)
 			capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
+			if eiContract.CxpVersion == 1 {
+				capCR = eiContract.MaxCoopSize - 1
+			}
+
 			diffCR := (float64(scoreBase) * 0.06) / float64(capCR)
 
 			var crBuilder strings.Builder
@@ -846,6 +850,9 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 		}
 		// Create a table of Contract Scores for this user
 		capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
+		if eiContract.CxpVersion == 1 {
+			capCR = eiContract.MaxCoopSize - 1
+		}
 		var csBuilder strings.Builder
 
 		// Maximum Contract Score with current buffs and max CR & TVAL


### PR DESCRIPTION
The changes in this commit adjust the calculation of the CR (Contribution Ratio) cap for
contracts with CxpVersion 1. For these contracts, the CR cap is set to the MaxCoopSize
minus 1, instead of the previous calculation based on contract duration. This ensures
that the CR cap is always one less than the MaxCoopSize for CxpVersion 1 contracts.