### PR TITLE
feat(contract): Simplify chicken run calculation

### DIFF
--- a/src/boost/siab.go
+++ b/src/boost/siab.go
@@ -810,11 +810,7 @@ func DownloadCoopStatusSiab(contractID string, coopID string, offsetEndTime time
 				eiContract.Grade[grade].LengthInSeconds,
 				contractDurationSeconds,
 				0, 0, 0)
-			capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
-			if eiContract.CxpVersion == 1 {
-				capCR = eiContract.MaxCoopSize - 1
-			}
-
+			capCR := eiContract.ChickenRuns
 			diffCR := (float64(scoreBase) * 0.06) / float64(capCR)
 
 			var crBuilder strings.Builder
@@ -841,11 +837,7 @@ func DownloadCoopStatusSiab(contractID string, coopID string, offsetEndTime time
 
 		}
 		// Create a table of Contract Scores for this user
-		capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
-		if eiContract.CxpVersion == 1 {
-			capCR = eiContract.MaxCoopSize - 1
-		}
-
+		capCR := eiContract.ChickenRuns
 		var csBuilder strings.Builder
 
 		// Maximum Contract Score with current buffs and max CR & TVAL

--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -818,10 +818,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 				eiContract.Grade[grade].LengthInSeconds,
 				contractDurationSeconds,
 				0, 0, 0)
-			capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
-			if eiContract.CxpVersion == 1 {
-				capCR = eiContract.MaxCoopSize - 1
-			}
+			capCR := eiContract.ChickenRuns
 
 			diffCR := (float64(scoreBase) * 0.06) / float64(capCR)
 
@@ -849,10 +846,7 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 
 		}
 		// Create a table of Contract Scores for this user
-		capCR := min((eiContract.MaxCoopSize*contractDurationInDays)/2, 20)
-		if eiContract.CxpVersion == 1 {
-			capCR = eiContract.MaxCoopSize - 1
-		}
+		capCR := eiContract.ChickenRuns
 		var csBuilder strings.Builder
 
 		// Maximum Contract Score with current buffs and max CR & TVAL


### PR DESCRIPTION
The changes simplify the calculation of the chicken run (CR) cap by
directly using the `eiContract.ChickenRuns` value instead of
calculating it based on the contract duration and maximum cooperative
size. This change makes the code more concise and easier to understand.