### PR TITLE
feat(boost): Improve token value calculation and display

### DIFF
--- a/src/boost/boost_calctval.go
+++ b/src/boost/boost_calctval.go
@@ -2,7 +2,6 @@ package boost
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"time"
@@ -145,13 +144,13 @@ func HandleContractCalcContractTvalCommand(s *discordgo.Session, i *discordgo.In
 	} else if !userInContract(contract, userID) {
 		str = "You are not part of this contract"
 	} else {
-		BTA := math.Floor(duration.Minutes() / float64(contract.MinutesPerToken))
-		targetTval := 3.0
-		if BTA > 42.0 {
-			targetTval = 0.07 * BTA
-		}
+		targetTval := GetTargetTval(contract.CxpVersion, duration.Minutes(), float64(contract.MinutesPerToken))
 		// Calculate the token value
-		embed = calculateTokenValueFromLog(contract, duration, details, targetTval, userID)
+		if targetTval == 0.0 {
+			str += "This contract does not have a target token value requirement.\n"
+		} else {
+			embed = calculateTokenValueFromLog(contract, duration, details, targetTval, userID)
+		}
 
 	}
 	if invalidDuration {

--- a/src/boost/boost_draw.go
+++ b/src/boost/boost_draw.go
@@ -2,7 +2,6 @@ package boost
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -63,11 +62,8 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 	tokenStr := contract.TokenStr
 	divider := true
 	spacing := discordgo.SeparatorSpacingSizeSmall
-	targetTval := 3.0
-	BTA := math.Floor(float64(contract.EstimatedDuration.Minutes()) / float64(contract.MinutesPerToken))
-	if BTA > 42.0 {
-		targetTval = 0.07 * BTA
-	}
+
+	targetTval := GetTargetTval(contract.CxpVersion, contract.EstimatedDuration.Minutes(), float64(contract.MinutesPerToken))
 
 	var bannerItem discordgo.MediaGalleryItem
 
@@ -199,8 +195,10 @@ func DrawBoostList(s *discordgo.Session, contract *Contract) []discordgo.Message
 				contract.EstimatedDuration = c.EstimatedDuration
 			}
 		}
-		currentTval = bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
-		builder.WriteString(fmt.Sprintf("> TVal: 🎯%2.2f 📉%2.2f\n", targetTval, currentTval))
+		if targetTval != 0.0 {
+			currentTval = bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
+			builder.WriteString(fmt.Sprintf("> TVal: 🎯%2.2f 📉%2.2f\n", targetTval, currentTval))
+		}
 	}
 
 	if !contract.EstimateUpdateTime.IsZero() {

--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -351,7 +351,10 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 	if (contract.State == ContractStateSignup || contract.State == ContractStateBanker) && contract.Style&ContractFlagBanker != 0 {
 		sinkList = append(sinkList, SinkList{"Banker", "🏦", contract.Banker.BoostingSinkUserID, "boostsink"})
 	}
-	sinkList = append(sinkList, SinkList{"Post Contract Sink", "🏁", contract.Banker.PostSinkUserID, "postsink"})
+	if contract.CxpVersion != 1 {
+		// New contracts fom 9/22/2025 on don't have token value requirements
+		sinkList = append(sinkList, SinkList{"Post Contract Sink", "🏁", contract.Banker.PostSinkUserID, "postsink"})
+	}
 
 	var mComp []discordgo.MessageComponent
 	for _, sink := range sinkList {

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -3,7 +3,6 @@ package boost
 import (
 	"fmt"
 	"log"
-	"math"
 	"sort"
 	"strings"
 	"time"
@@ -595,11 +594,7 @@ func HandleTokenEditCommand(s *discordgo.Session, i *discordgo.InteractionCreate
 		}
 	}
 	// Recalculate token values after the change
-	targetTval := 3.0
-	BTA := math.Floor(c.EstimatedDuration.Minutes() / float64(c.MinutesPerToken))
-	if BTA > 42.0 {
-		targetTval = 0.07 * BTA
-	}
+	targetTval := GetTargetTval(c.CxpVersion, c.EstimatedDuration.Minutes(), float64(c.MinutesPerToken))
 	calculateTokenValueCoopLog(c, c.EstimatedDuration, targetTval)
 
 	c.mutex.Unlock()

--- a/src/boost/contract_scores.go
+++ b/src/boost/contract_scores.go
@@ -24,6 +24,22 @@ import (
 		return buffTimeValue, B
 	}
 */
+
+// GetTargetTval will return the target tval for the contract based on the contract duration and minutes per token
+func GetTargetTval(cxpVersion int, contractMinutes float64, minutesPerToken float64) float64 {
+	if cxpVersion == 1 {
+		// Sept 22, 2025 and newer contracts don't have token value requirements
+		return 0.0
+	}
+	BTA := math.Floor(contractMinutes / minutesPerToken)
+	targetTval := 3.0
+	if BTA > 42.0 {
+		targetTval = 0.07 * BTA
+	}
+
+	return targetTval
+}
+
 func calculateChickenRunTeamwork(coopSize int, durationInDays int, runs int) float64 {
 	fCR := max(12.0/(float64(coopSize*durationInDays)), 0.3)
 	CR := min(fCR*float64(runs), 6.0)

--- a/src/boost/estimate_time.go
+++ b/src/boost/estimate_time.go
@@ -143,18 +143,6 @@ func getContractEstimateString(contractID string) string {
 		str += fmt.Sprintf(" / 🏠💲 %1.3gx", c.ModifierHabCost)
 	}
 	str += "\n"
-	/*
-		BTA := c.EstimatedDuration.Minutes() / float64(c.MinutesPerToken)
-		targetTval := 3.0
-		if BTA > 42.0 {
-			targetTval = 0.07 * BTA
-		}
-		BTALower := c.EstimatedDurationLower.Minutes() / float64(c.MinutesPerToken)
-		targetTvalLower := 3.0
-		if BTALower > 42.0 {
-			targetTvalLower = 0.07 * BTALower
-		}
-	*/
 	estStr := c.EstimatedDuration.Round(time.Minute).String()
 	estStr = strings.TrimRight(estStr, "0s")
 	estStrLower := c.EstimatedDurationLower.Round(time.Minute).String()

--- a/src/boost/score_explorer.go
+++ b/src/boost/score_explorer.go
@@ -20,7 +20,7 @@ var tokenSentValueStr = []string{"Tval Met", "3", "1", "0", "Sink"}
 var tokenSentValue = []float64{50, 3, 1, 0, 20}
 var tokenRecvValueStr = []string{"8", "6", "1", "0", "Sink"}
 var tokenRecvValue = []float64{8, 6, 1, 0, 1000}
-var chickenRunsStr = []string{"Max", "CoopSize", "CoopSize -1", "None"}
+var chickenRunsStr = []string{"Max", "None"}
 var siabDurationStr = []string{"30m", "45m", "Half Duration", "Full Duration"}
 var deflectorDurationsStr = []string{"Full Duration", "Boost Time"}
 
@@ -168,14 +168,14 @@ func HandleScoreExplorerCommand(s *discordgo.Session, i *discordgo.InteractionCr
 		FairShare:            2,
 		TvalSent:             0,
 		TvalReceived:         1,
-		ChickenRuns:          2,
+		ChickenRuns:          0,
 		contractInfo:         getContractEstimateString(contractID),
 	}
 
 	playStyleValues := []float64{1.0, 1.0, 1.20, 2.0}
 	scoreCalcParams.PlayStyleValues = append(scoreCalcParams.PlayStyleValues, playStyleValues...)
 	// Calculate CR Values
-	crValues := []int{c.ChickenRuns, c.MaxCoopSize, c.MaxCoopSize - 1, 0}
+	crValues := []int{c.ChickenRuns, 0}
 	scoreCalcParams.chickenRunValues = append(scoreCalcParams.chickenRunValues, crValues...)
 
 	siabTimes := []int{30, 45, -1, -1}


### PR DESCRIPTION
- Refactor token value calculation to use a new `GetTargetTval` function
  that handles different contract versions
- Remove unused code related to chicken runs and target token value
  calculation
- Display the target token value and current token value in the contract
  details, but only for contracts that have a target token value
  requirement