### PR TITLE
feat(boost): Optimize token value updates and reordering

### DIFF
--- a/src/boost/boost_button_reactions.go
+++ b/src/boost/boost_button_reactions.go
@@ -200,7 +200,9 @@ func buttonReactionToken(s *discordgo.Session, GuildID string, ChannelID string,
 			b.TokensReceived += count
 			contract.TokenLog = append(contract.TokenLog, ei.TokenUnitLog{Time: time.Now(), Quantity: count, FromUserID: fromUserID, FromNick: contract.Boosters[fromUserID].Nick, ToUserID: fromUserID, ToNick: contract.Boosters[fromUserID].Nick, Serial: xid.New().String(), Boost: false})
 			contract.mutex.Unlock()
-			reorderBoosters(contract)
+			if contract.BoostOrder == ContractOrderTVal {
+				reorderBoosters(contract)
+			}
 		}
 		if b.TokensReceived == b.TokensWanted {
 			b.BoostingTokenTimestamp = time.Now()

--- a/src/boost/state_banker.go
+++ b/src/boost/state_banker.go
@@ -58,9 +58,6 @@ func buttonReactionBag(s *discordgo.Session, GuildID string, ChannelID string, c
 			tval := bottools.GetTokenValue(time.Since(contract.StartTime).Seconds(), contract.EstimatedDuration.Seconds())
 			contract.Boosters[cUserID].TokenValue += tval * float64(tokensToSend)
 			contract.Boosters[b.UserID].TokenValue -= tval * float64(tokensToSend)
-			// Don't reorder on the bag send as we need a tiny amount of stability for the send to get to the correct person
-			//reorderBoosters(contract)
-			//}
 			if contract.Style&ContractFlagDynamicTokens != 0 {
 				// Determine the dynamic tokens
 				determineDynamicTokens(contract)


### PR DESCRIPTION
Optimize the token value updates and reordering logic in the
`state_banker.go` and `boost_button_reactions.go` files. The changes
include:

- Remove unnecessary comments and code related to reordering boosters
  after token transfers, as this is not required for the "tiny amount
  of stability" mentioned.
- Introduce a conditional check to only reorder boosters when the
  contract's `BoostOrder` is set to `ContractOrderTVal`.
- This change ensures that the reordering logic is only applied when
  necessary, improving the overall performance and stability of the
  token value updates.