### PR TITLE
feat(boost): add conditional check for message components

### DIFF
--- a/src/boost/boost_handlers.go
+++ b/src/boost/boost_handlers.go
@@ -404,7 +404,10 @@ func GetSignupComponents(contract *Contract) (string, []discordgo.MessageCompone
 			}
 		}
 	}
-	buttons = append(buttons, discordgo.ActionsRow{Components: mComp})
+
+	if len(mComp) > 0 {
+		buttons = append(buttons, discordgo.ActionsRow{Components: mComp})
+	}
 
 	return str, buttons
 }


### PR DESCRIPTION
Adds a conditional check to ensure that the message components are only
appended to the buttons if the slice is not empty. This prevents the
creation of an empty actions row in the Discord message.