### PR TITLE
feat(boost): Adjust delivery time message and increase laying rate

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -348,7 +348,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 	}
 
 	if adjustedRemainingTime == -1 {
-		fmt.Fprintf(&header, "**Deliver %s%s in more than 2 years**",
+		fmt.Fprintf(&header, "**Deliver %s%s in more than a year**",
 			ei.FormatEIValue(selectedTarget, map[string]interface{}{"decimals": 1, "trim": true}),
 			selectedEggEmote)
 	} else if adjustedRemainingTime < 24.0 {

--- a/src/ei/research.go
+++ b/src/ei/research.go
@@ -633,14 +633,14 @@ func TimeToDeliverEggs(initialPop, maxPop, growthRatePerMinute, layingRatePerHou
 			}
 			// want % of pop increase so we can increase the delivery rate
 			popIncrease := currentPop - oldPop
-			deliveryRate *= (1 + popIncrease/oldPop)
+			layingRatePerStep *= (1 + popIncrease/oldPop)
 		}
 
 		// Increment time
 		totalTimeMinutes += timeStepMinutes
 
 		// Safety break to prevent infinite loops if the target is unreachable.
-		if totalTimeMinutes > 1_051_200 { // A large number of minutes as a safety limit
+		if totalTimeMinutes > 525_600 { // 1 year in minutes
 			return -1.0
 		}
 	}


### PR DESCRIPTION
The changes made in this commit include:

1. Updating the delivery time message in the `virtue.go` file to display "in more than a year" instead of "in more than 2 years".
2. Modifying the `research.go` file to increase the laying rate per step based on the population increase, instead of the delivery rate.
3. Reducing the safety time limit from 1,051,200 minutes (approximately 2 years) to 525,600 minutes (1 year) to prevent infinite loops.

These changes aim to improve the user experience by providing more accurate delivery time information and optimizing the research process.