### PR TITLE
feat(virtue): Display artifact stats in separate section

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -371,11 +371,12 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 
 	// If we have a selected egg type, show time to next TE
 
-	fmt.Fprintf(&footer, "-# Artifacts  SR:%v%%  ELR:%v%%  IHR:%v%%  Hab:%v%%. Max Colleggtibles Assumed.\n",
+	fmt.Fprintf(&stats, "**Artifacts**  SR:%v%%  ELR:%v%%  IHR:%v%%  Hab:%v%%.\n",
 		math.Round((artifactSR-1)*100),
 		math.Round((artifactELR-1)*100),
 		math.Round((artifactIHR-1)*100),
 		math.Round((artifactHab-1)*100))
+	fmt.Fprint(&footer, "-# Max Colleggtibles Assumed.\n")
 	fmt.Fprintf(&footer, "-# Report run <t:%d:t>, last sync <t:%d:t>\n", time.Now().Unix(), syncTime.Unix())
 
 	// Line for fuel


### PR DESCRIPTION
Displays the artifact stats (SR, ELR, IHR, Hab) in a separate section
from the "Max Colleggtibles Assumed" message. This makes the artifact
stats more prominent and easier to read.