### PR TITLE
feat: Asynchronously write backup JSON file

### DIFF
--- a/src/ei/ei_api.go
+++ b/src/ei/ei_api.go
@@ -123,19 +123,21 @@ func GetFirstContactFromAPI(s *discordgo.Session, eiUserID string, discordID str
 		return nil, cachedData
 	}
 	// Write the backup as a JSON file for debugging purposes
-	jsonData, err := json.MarshalIndent(backup, "", "  ")
-	// Swap all instances of eiUserID with "REDACTED"
-	jsonData = []byte(string(jsonData))
-	jsonData = []byte(RedactUserInfo(string(jsonData), eiUserID))
-	if err != nil {
-		log.Println("Error marshalling backup to JSON:", err)
-	} else {
-		_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
-		err = os.WriteFile("ttbb-data/eiuserdata/firstcontact-"+discordID+".json", []byte(jsonData), 0644)
+	go func() {
+		jsonData, err := json.MarshalIndent(backup, "", "  ")
+		// Swap all instances of eiUserID with "REDACTED"
+		jsonData = []byte(string(jsonData))
+		jsonData = []byte(RedactUserInfo(string(jsonData), eiUserID))
 		if err != nil {
-			log.Print(err)
+			log.Println("Error marshalling backup to JSON:", err)
+		} else {
+			_ = os.MkdirAll("ttbb-data/eiuserdata", os.ModePerm)
+			err = os.WriteFile("ttbb-data/eiuserdata/firstcontact-"+discordID+".json", []byte(jsonData), 0644)
+			if err != nil {
+				log.Print(err)
+			}
 		}
-	}
+	}()
 
 	return backup, cachedData
 }


### PR DESCRIPTION
This change moves the JSON file writing for the backup data into a
separate goroutine, allowing the main function to return the backup
data more quickly without waiting for the file write to complete.
The redaction of the eiUserID in the JSON data is also preserved in
this change.