### PR TITLE
feat: Improve Chicken Run display for CXP v1 contracts

### DIFF
--- a/src/boost/teamwork.go
+++ b/src/boost/teamwork.go
@@ -841,8 +841,12 @@ func DownloadCoopStatusTeamwork(contractID string, coopID string, offsetEndTime 
 				}
 				crBuilder.WriteString(fmt.Sprintf("\nEach Chicken Run adds %6.3f to Contract Score with current buffs%s", diffCR, tvalString))
 			}
+			str := "Chicken Runs w/No Token Sharing"
+			if eiContract.CxpVersion == 1 {
+				str = "Chicken Runs"
+			}
 			field = append(field, &discordgo.MessageEmbedField{
-				Name:   "Chicken Runs w/No Token Sharing",
+				Name:   str,
 				Value:  "```" + crBuilder.String() + "```",
 				Inline: false,
 			})


### PR DESCRIPTION
Adds a conditional check to display the correct Chicken Run label based on the
CXP version of the contract. For CXP v1 contracts, the label is simply
"Chicken Runs", while for other versions it is "Chicken Runs w/No Token
Sharing".