### PR TITLE
feat(virtue): Improve habitat handling and time calculations

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -195,10 +195,12 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 	var habArray []string
 	for _, h := range farm.GetHabs() {
 		id := h // h is already a uint32 representing the habitat ID
-		if int(id) > highestHab {
+		if int(id) > highestHab && int(id) < 19 {
 			highestHab = int(id + 1)
 		}
-		habArray = append(habArray, ei.GetBotEmojiMarkdown(fmt.Sprintf("hab%d", id+1)))
+		if int(id) < 19 {
+			habArray = append(habArray, ei.GetBotEmojiMarkdown(fmt.Sprintf("hab%d", id+1)))
+		}
 	}
 	habArt := ei.GetBotEmojiMarkdown(fmt.Sprintf("hab%d", highestHab))
 
@@ -319,7 +321,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 	offlineFillTime := ei.TimeForLinearGrowth(habPop, habCap, offlineRate/60)
 	syncTime := time.Unix(int64(backup.GetApproxTime()), 0)
 	remainingTime := ei.TimeToDeliverEggs(habPop, habCap, offlineRate, eggLayingRate-fuelRate, shippingRate, selectedTarget-selectedDelivered)
-	elapsed := time.Since(syncTime).Hours()
+	elapsed := time.Since(syncTime).Seconds()
 	adjustedRemainingTime := remainingTime - elapsed
 	offlineEggs := min(eggLayingRate, shippingRate) * elapsed
 
@@ -370,20 +372,20 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 			time.Now().Add(time.Duration(int64(offlineFillTime))*time.Second).Unix())
 	}
 
-	if adjustedRemainingTime == -1 {
+	if remainingTime == -1.0 {
 		fmt.Fprintf(&header, "**Deliver %s%s in more than a year**",
 			ei.FormatEIValue(selectedTarget, map[string]interface{}{"decimals": 1, "trim": true}),
 			selectedEggEmote)
-	} else if adjustedRemainingTime < 24.0 {
+	} else if adjustedRemainingTime < 86400.0 { // 1 day
 		fmt.Fprintf(&header, "**Deliver %s%s <t:%d:R>**",
 			ei.FormatEIValue(selectedTarget, map[string]interface{}{"decimals": 1, "trim": true}),
 			selectedEggEmote,
-			time.Now().Add(time.Duration(int64(adjustedRemainingTime))*time.Hour).Unix())
+			time.Now().Add(time.Duration(int64(adjustedRemainingTime))*time.Second).Unix())
 	} else {
 		fmt.Fprintf(&header, "**Deliver %s%s <t:%d:f>**💤",
 			ei.FormatEIValue(selectedTarget, map[string]interface{}{"decimals": 1, "trim": true}),
 			selectedEggEmote,
-			time.Now().Add(time.Duration(int64(adjustedRemainingTime))*time.Hour).Unix())
+			time.Now().Add(time.Duration(int64(adjustedRemainingTime))*time.Second).Unix())
 	}
 	fmt.Fprintf(&header, "\n-# includes %s offline eggs", ei.FormatEIValue(offlineEggs, map[string]interface{}{"decimals": 1, "trim": true}))
 

--- a/src/ei/research.go
+++ b/src/ei/research.go
@@ -91,9 +91,6 @@ func GetVehiclesShippingCapacity(vehicles []uint32, trainLength []uint32, univMu
 	fullyUpgraded := true
 
 	for i, v := range vehicles {
-		if v == 0 {
-			continue
-		}
 		vehicleType := vehicleTypes[v]
 		capacity := vehicleType.BaseCapacity
 		if vehicleType.ID != 11 && trainLength[i] != 10 {
@@ -587,7 +584,7 @@ func TimeForLinearGrowth(initialPopulation, targetPopulation, growthRate float64
 //
 // Returns:
 //
-//	The time in hours, or -1 if the target is unreachable.
+//	The time in seconds, or -1 if the target is unreachable.
 func TimeToDeliverEggs(initialPop, maxPop, growthRatePerMinute, layingRatePerHour, shippingRatePerHour, targetEggs float64) float64 {
 	// Validate inputs
 	if initialPop <= 0 || maxPop <= 0 || growthRatePerMinute <= 0 || layingRatePerHour <= 0 || targetEggs <= 0 {
@@ -642,7 +639,7 @@ func TimeToDeliverEggs(initialPop, maxPop, growthRatePerMinute, layingRatePerHou
 		}
 	}
 
-	return totalTimeMinutes / 60.0
+	return totalTimeMinutes * 60.0
 }
 
 // GetArtifactBuffs calculates the total buffs from artifacts


### PR DESCRIPTION
This commit includes the following changes:

1. Limit the habitat array to only include habitats up to 18, as habitat 19 is not
   a valid habitat.
2. Adjust the calculation of the `elapsed` time to use seconds instead of hours,
   improving the accuracy of the remaining time calculation.
3. Modify the remaining time display logic to use seconds instead of hours, and
   adjust the formatting accordingly.

These changes help ensure the correct handling of habitat information and improve
the accuracy of the time calculations, providing a better user experience.