### PR TITLE
feat: Adjust highest vehicle ID to 0

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -204,7 +204,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 	}
 	habArt := ei.GetBotEmojiMarkdown(fmt.Sprintf("hab%d", highestHab))
 
-	highestVehicle := 1
+	highestVehicle := 0
 	for _, v := range farm.GetVehicles() {
 		id := v // v is already a uint32 representing the vehicle ID
 		if int(id) > highestVehicle {


### PR DESCRIPTION
The changes in this commit adjust the calculation of the highest vehicle ID
from 1 to 0. This ensures that the correct vehicle emoji is displayed for
farms with no vehicles.