### PR TITLE
feat: Adjust offline egg calculation to use hours

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -323,7 +323,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 	remainingTime := ei.TimeToDeliverEggs(habPop, habCap, offlineRate, eggLayingRate-fuelRate, shippingRate, selectedTarget-selectedDelivered)
 	elapsed := time.Since(syncTime).Seconds()
 	adjustedRemainingTime := remainingTime - elapsed
-	offlineEggs := min(eggLayingRate, shippingRate) * elapsed
+	offlineEggs := min(eggLayingRate, shippingRate) * (elapsed * 60 * 60)
 
 	// Want time from now when those minutes elapse
 	if shippingRate > eggLayingRate {


### PR DESCRIPTION
The changes adjust the offline egg calculation to use hours instead of
seconds. This ensures that the offline egg production is calculated
correctly when the game is not running.