### PR TITLE
feat: Simplify variable declaration in virtue.go

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -220,7 +220,7 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 
 	var allEov uint32 = 0
 	var futureEov uint32 = 0
-	var onVirtueFarm bool = false
+	var onVirtueFarm = false
 
 	selectedTarget := 0.0
 	selectedDelivered := 0.0


### PR DESCRIPTION
Simplify the declaration of the `onVirtueFarm` variable by removing the
explicit boolean assignment. This makes the code more concise and
readable without changing the functionality.