### PR TITLE
feat(boost): improve contract score estimation

### DIFF
--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -181,8 +181,11 @@ type EggIncContract struct {
 	ContractVersion           int // 1 = old, 2 = new
 	Grade                     []ContractGrade
 	TeamNames                 []string // Names of the teams in the contract
-	Cxp                       float64  // CXP value for the contract
-	CxpVersion                int      // 0 = old (0.2.0), true = 1 (0.3.0+ sesonals & AA+AAA)
+	// Contract Scoring Values
+	CxpBuffOnly float64 // Minimum score with only CR/TVal
+	CxpRunDelta float64 // Individual chicken run addition
+	Cxp         float64 // CXP value for the contract
+	CxpVersion  int     // 0 = old (0.2.0), true = 1 (0.3.0+ sesonals & AA+AAA)
 }
 
 // EggIncContracts holds a list of all contracts, newest is last


### PR DESCRIPTION
This commit improves the contract score estimation logic in the `boost_import.go` file. The key changes are:

1. Removed the commented-out code that calculated the contract score with different teamwork multipliers, as the new logic supersedes this.
2. Introduced a `fairShare` variable to handle the different CXP version calculations. For CXP version 1, the fair share is set to 1.02, while for CXP version 2, it is set to 1.05.
3. Calculated the base contract score without any teamwork multipliers, and used this to compute the CXP run delta, which represents the CXP gained per chicken run.
4. Introduced a `CxpBuffOnly` field to store the contract score with only the buffs included, without any chicken runs.
5. Simplified the contract score estimation logic in the `estimate_time.go` file, removing the unnecessary "Best Effort" score and focusing on the "Sink" score, which represents the worst-case scenario.

These changes improve the accuracy and clarity of the contract score estimation, making it easier to understand and use.