### PR TITLE
feat: Improve fuel warning logic in virtue.go

### DIFF
--- a/src/boost/virtue.go
+++ b/src/boost/virtue.go
@@ -362,7 +362,8 @@ func printVirtue(backup *ei.Backup) []discordgo.MessageComponent {
 			warningLamp := ""
 			if fuelPercentage == 1.0 {
 				warningLamp = "⚠🚨"
-			} else if shippingRate > eggLayingRate {
+			}
+			if shippingRate > eggLayingRate {
 				fmt.Fprintf(&stats, " ⛽️%s **%s**/hr\n",
 					warningLamp,
 					ei.FormatEIValue(fuelRate, map[string]interface{}{"decimals": 2, "trim": true}))


### PR DESCRIPTION
The changes in this commit improve the fuel warning logic in the
virtue.go file. The warning lamp is now only displayed when the fuel
percentage is at 100%, and a separate check is added to display the
shipping rate when it exceeds the egg laying rate.