### PR TITLE
feat: switch on egg.Dimension when computing buffsRefactor conditional logic in ei_art.go to use a switch onegg.Dimension instead of chained if/else when extracting thelatestValue for shipping and/hab capacity.

### DIFF
--- a/src/ei/ei_artifacts.go
+++ b/src/ei/ei_artifacts.go
@@ -573,11 +573,12 @@ func PopulateColleggtiblesInArtifactMap() {
 		shipBuff := 1.0
 		layBuff := 1.0
 
-		if egg.Dimension == GameModifier_SHIPPING_CAPACITY {
+		switch egg.Dimension {
+		case GameModifier_SHIPPING_CAPACITY:
 			if len(egg.DimensionValue) > 0 {
 				shipBuff = egg.DimensionValue[len(egg.DimensionValue)-1]
 			}
-		} else if egg.Dimension == GameModifier_EGG_LAYING_RATE || egg.Dimension == GameModifier_HAB_CAPACITY {
+		case GameModifier_EGG_LAYING_RATE, GameModifier_HAB_CAPACITY:
 			if len(egg.DimensionValue) > 0 {
 				layBuff = egg.DimensionValue[len(egg.DimensionValue)-1]
 			}


### PR DESCRIPTION
- Replace/else with switch covering:
 - GameModifier_SHIPPING_CAP -> set shipBuff from last value - GameModifier_EGG_LAYING, GameModifierAB_CAPACITY ->
 set layBuff from last valueThis clarifies intent, groups related cases, and simplifies addingfuture dimensions.