### PR TITLE
✨ feat: improve downloads, artifact access, and admin checks- src/bottools/banners.go: add failedDownloads counter and track failures (HTTP status, download/create/write errors).

### DIFF
--- a/src/boost/artifacts.go
+++ b/src/boost/artifacts.go
@@ -467,9 +467,9 @@ func HandleArtifactReactions(s *discordgo.Session, i *discordgo.InteractionCreat
 			}
 			var newArtifact *ei.Artifact
 			if len(data.Values) == 0 {
-				newArtifact = ei.ArtifactMap[prefix+"NONE"]
+				newArtifact = ei.GetArtifactByKey(prefix + "NONE")
 			} else {
-				newArtifact = ei.ArtifactMap[prefix+data.Values[0]]
+				newArtifact = ei.GetArtifactByKey(prefix + data.Values[0])
 			}
 
 			// Check if artifact was found in map

--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -631,7 +631,7 @@ func getUserArtifacts(userID string, inSet *ArtifactSet) ArtifactSet {
 					art = strings.ReplaceAll(art, "FLAMERETARDANT", "FLAME RETARDANT")
 
 					if a != "" {
-						colleg := ei.ArtifactMap[art]
+						colleg := ei.GetArtifactByKey(art)
 						if colleg != nil {
 							mySet.Artifacts = append(mySet.Artifacts, *colleg)
 						}
@@ -639,7 +639,7 @@ func getUserArtifacts(userID string, inSet *ArtifactSet) ArtifactSet {
 				}
 			} else {
 				if art != "" {
-					a := ei.ArtifactMap[prefix[i]+art]
+					a := ei.GetArtifactByKey(prefix[i] + art)
 					if a != nil {
 						//fmt.Print(prefix[i]+art, a)
 						mySet.Artifacts = append(mySet.Artifacts, *a)

--- a/src/bottools/banners.go
+++ b/src/bottools/banners.go
@@ -433,6 +433,8 @@ func DownloadLatestEggImages(localDownloadDir string) error {
 		return fmt.Errorf("error getting repository contents: %w", err)
 	}
 
+	failedDownloads := 0
+
 	for _, content := range directoryContents {
 		// Only process files.
 		if content.GetType() == "file" {
@@ -466,6 +468,7 @@ func DownloadLatestEggImages(localDownloadDir string) error {
 			resp, err := http.Get(downloadURL)
 			if err != nil {
 				log.Printf("Error downloading file %s: %v\n", content.GetName(), err)
+				failedDownloads++
 				continue
 			}
 			defer func() {
@@ -475,9 +478,16 @@ func DownloadLatestEggImages(localDownloadDir string) error {
 				}
 			}()
 
+			if resp.StatusCode < 200 || resp.StatusCode > 299 {
+				log.Printf("Error downloading file %s: unexpected status %s\n", content.GetName(), resp.Status)
+				failedDownloads++
+				continue
+			}
+
 			outFile, err := os.Create(localFilePath)
 			if err != nil {
 				log.Printf("Error creating local file %s: %v\n", localFilePath, err)
+				failedDownloads++
 				continue
 			}
 			defer func() {
@@ -490,10 +500,15 @@ func DownloadLatestEggImages(localDownloadDir string) error {
 			// Copy the downloaded content to the local file.
 			if _, err := io.Copy(outFile, resp.Body); err != nil {
 				log.Printf("Error writing to file %s: %v\n", localFilePath, err)
+				failedDownloads++
 				continue
 			}
 			log.Printf("Successfully downloaded %s.\n", content.GetName())
 		}
+	}
+
+	if failedDownloads > 0 {
+		return fmt.Errorf("download scan completed with %d failed file(s)", failedDownloads)
 	}
 
 	// Update the sentinel so we don't re-scan until next week.

--- a/src/ei/ei_artifacts.go
+++ b/src/ei/ei_artifacts.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -187,6 +188,15 @@ var ArtifactMap = map[string]*Artifact{
 	"G-T2E":  {Type: "Gusset", Quality: "T2E", ShipBuff: 1.0, LayBuff: 1.12, DeflBuff: 1.0, Stones: 0},
 	"G-NONE": {Type: "Gusset", Quality: "NONE", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
 	"NONE":   {Type: "Collegg", Quality: "NONE", ShipBuff: 1.0, LayBuff: 1.0, DeflBuff: 1.0, Stones: 0},
+}
+
+var artifactMapMu sync.RWMutex
+
+// GetArtifactByKey safely returns an artifact entry from ArtifactMap.
+func GetArtifactByKey(key string) *Artifact {
+	artifactMapMu.RLock()
+	defer artifactMapMu.RUnlock()
+	return ArtifactMap[key]
 }
 
 var data *Store
@@ -545,6 +555,9 @@ func GetBestCoopArtifactsFromInventory(items []*ArtifactInventoryItem) map[strin
 
 // PopulateColleggtiblesInArtifactMap dynamically populates the ArtifactMap with colleggtibles from CustomEggMap
 func PopulateColleggtiblesInArtifactMap() {
+	artifactMapMu.Lock()
+	defer artifactMapMu.Unlock()
+
 	// First remove existing dynamic Collegg entries (except "NONE")
 	for key, art := range ArtifactMap {
 		if art.Type == "Collegg" && key != "NONE" {

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -55,7 +56,7 @@ var lastEventUpdate time.Time
 
 // GetSlashForceDownloadCommand returns a home-guild-only command to force re-download all data files.
 func GetSlashForceDownloadCommand(cmd string) *discordgo.ApplicationCommand {
-	var adminPermission int64 = 0
+	var adminPermission int64 = discordgo.PermissionAdministrator
 
 	guildID := guildstate.GetGuildSettingString("DEFAULT", "home_guild")
 	if guildID == "" {
@@ -92,6 +93,29 @@ func GetSlashForceDownloadCommand(cmd string) *discordgo.ApplicationCommand {
 
 // HandleForceDownloadCommand handles the home-guild force-download command.
 func HandleForceDownloadCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	userID := ""
+	if i.GuildID == "" {
+		userID = i.User.ID
+	} else {
+		userID = i.Member.User.ID
+	}
+
+	perms, err := s.UserChannelPermissions(userID, i.ChannelID)
+	if err != nil {
+		log.Println(err)
+	}
+	if perms&discordgo.PermissionAdministrator == 0 && userID != config.AdminUserID {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content:    "You are not authorized to use this command.",
+				Flags:      discordgo.MessageFlagsEphemeral,
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -258,13 +282,64 @@ type manifestEntry struct {
 	ETag      string    `json:"etag,omitempty"`
 }
 
+var rareFetchRandMu sync.Mutex
+var rareFetchRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 // rareFetchInterval returns a randomized duration between 20 and 30 days,
 // used for files that change infrequently to spread out network checks.
 func rareFetchInterval() time.Duration {
-	return time.Duration(20+rand.Intn(11)) * 24 * time.Hour
+	rareFetchRandMu.Lock()
+	defer rareFetchRandMu.Unlock()
+	return time.Duration(20+rareFetchRand.Intn(11)) * 24 * time.Hour
 }
 
 var manifestMutex sync.Mutex
+var downloadFileLocks sync.Map
+
+func lockDownloadFile(filename string) func() {
+	mu, _ := downloadFileLocks.LoadOrStore(filename, &sync.Mutex{})
+	fileMu := mu.(*sync.Mutex)
+	fileMu.Lock()
+	return fileMu.Unlock
+}
+
+func writeFileAtomic(filename string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(filename)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err := tmpFile.Write(content); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(perm); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpName, filename); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func getManifestEntry(filename string) manifestEntry {
 	manifestMutex.Lock()
@@ -293,8 +368,7 @@ func updateManifestEntry(filename string, etag string) {
 	}
 	manifest[filename] = manifestEntry{LastCheck: time.Now(), ETag: etag}
 	if b, err := json.MarshalIndent(manifest, "", "  "); err == nil {
-		_ = os.MkdirAll("ttbb-data", os.ModePerm)
-		_ = os.WriteFile("ttbb-data/download-manifest.json", b, 0644)
+		_ = writeFileAtomic("ttbb-data/download-manifest.json", b, 0644)
 	}
 }
 
@@ -356,6 +430,9 @@ func cronPruneOldGeneratedBanners() {
 }
 
 func downloadEggIncData(urlStr string, filename string, force bool, maxAge time.Duration) bool {
+	unlock := lockDownloadFile(filename)
+	defer unlock()
+
 	entry := getManifestEntry(filename)
 
 	if !force {
@@ -417,7 +494,7 @@ func downloadEggIncData(urlStr string, filename string, force bool, maxAge time.
 	}
 
 	// Save to disk
-	err = os.WriteFile(filename, body, 0644)
+	err = writeFileAtomic(filename, body, 0644)
 	if err != nil {
 		log.Print(err)
 		return false


### PR DESCRIPTION
Return error summarizing number of failed files when any fail.
 This prevents silent failures during banner sync and ensures the caller is aware of partial download problems.
- src/boost/boost.go, src/boostifacts.go, src/ei/ei_artifacts.go:
 replace direct ArtifactMap access with thread-safe GetArtifactByKey.
 Introduce artifactMapMu RWMutex and protect dynamic population of colleggtibles with a write lock. This prevents race conditions when artifacts are read/modified concurrently.
- src/ei/ei_artifacts.go: add GetArtifactByKey helper and mutex to guard ArtifactMap access.
- src/tasks/tasks.go: import filepath, set slash command to require Administrator permission by default, and enforce runtime admin check for force-download interactions. Respond with a clear ephemeral error when unauthorized. This tightens command security and prevents unauthorized force-downloads.