### PR TITLE
✨ feat(banners fix banner guild/ ordering and regenenerate custom banners for contracts and correct path forcustom banner files so guild creator IDs are used.

### DIFF
--- a/src/bottools/banners.go
+++ b/src/bottools/banners.go
@@ -99,7 +99,7 @@ func GenerateBanner(ID string, eggName string, text string, creatorID string, gu
 
 	hasCustomBanner := false
 	if creatorID != "" {
-		bgCustomPath := fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, guildID, creatorID)
+		bgCustomPath := fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, creatorID, guildID)
 		if SyncCustomBannerCallback != nil {
 			hasCustomBanner = SyncCustomBannerCallback(creatorID, guildID, bgCustomPath)
 		} else {
@@ -111,13 +111,13 @@ func GenerateBanner(ID string, eggName string, text string, creatorID string, gu
 
 	for _, style := range styleArray {
 		if hasCustomBanner {
-			customImgPath := fmt.Sprintf("%s/%s-b%s-%s_%s.png", config.BannerOutputPath, ID, style, guildID, creatorID)
+			customImgPath := fmt.Sprintf("%s/%s-b%s-%s_%s.png", config.BannerOutputPath, ID, style, creatorID, guildID)
 			info, err := os.Stat(customImgPath)
 			if os.IsNotExist(err) {
 				allExistAndFresh = false
 				break
 			}
-			bgInfo, _ := os.Stat(fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, guildID, creatorID))
+			bgInfo, _ := os.Stat(fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, creatorID, guildID))
 			if bgInfo != nil && info.ModTime().Before(bgInfo.ModTime()) {
 				allExistAndFresh = false
 				break
@@ -192,7 +192,7 @@ func GenerateBanner(ID string, eggName string, text string, creatorID string, gu
 
 	bgSeasonPath := fmt.Sprintf("%s/banner_%s_640.png", config.BannerPath, currentSeason)
 	bgSpacePath := config.BannerPath + "/banner_space_640.png"
-	bgCustomPath := fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, guildID, creatorID)
+	bgCustomPath := fmt.Sprintf("%s/banner_%s_%s.png", config.BannerPath, creatorID, guildID)
 
 	if _, err := os.Stat(bgSeasonPath); os.IsNotExist(err) {
 		_ = DownloadLatestEggImages(config.BannerPath)
@@ -260,7 +260,7 @@ func GenerateBanner(ID string, eggName string, text string, creatorID string, gu
 
 	if hasCustomBanner {
 		backgrounds = []bgDef{
-			{path: bgCustomPath, suffix: fmt.Sprintf("-%s", creatorID)},
+			{path: bgCustomPath, suffix: fmt.Sprintf("-%s_%s", creatorID, guildID)},
 		}
 	} else {
 		backgrounds = []bgDef{

--- a/src/tasks/tasks.go
+++ b/src/tasks/tasks.go
@@ -281,6 +281,19 @@ func HandleReloadContractsCommand(s *discordgo.Session, i *discordgo.Interaction
 		contract.Egg = originalContract.Egg
 		contract.EggName = originalContract.EggName
 		contract.EggEmoji = boost.FindEggEmoji(originalContract.EggName)
+
+		// Regenerate banners for contracts with a custom banner so they are
+		// up to date in case the banner image was updated or never generated.
+		if len(contract.CreatorID) > 0 {
+			guildID := contract.Location[0].GuildID
+			bannerText := contract.Name
+			if bannerText == "" {
+				bannerText = originalContract.Name
+			}
+			if bannerText != "" && contract.EggName != "" {
+				go bottools.GenerateBanner(contract.ContractID, contract.EggName, bannerText, contract.CreatorID[0], guildID, "")
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
- Add a step when loading contracts if a contract a creator an egg name, spawn gor to call Generate to refresh or custom banner images. ensures banners stay to date images change or were generated.
- Fix construction and freshness checks bottools/b:
 swapID and creatorID order when composing bgCustomPath and custom image output filenames so the same ordering is used for both lookup and. Also adjust output suffix formatting to both creator and guild IDs.

These changes prevent mismatched lookups and ensure custom bannersare generated when needed.