### PR TITLE
✨ feat: add contract history tracking and memory estimation- Add field ei.EggIncContract to retain replaced versions of contracts for auditing and to allow lookup of prior states.

### DIFF
--- a/src/boost/boost_import.go
+++ b/src/boost/boost_import.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/config"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 
 	"google.golang.org/protobuf/proto"
@@ -58,11 +60,24 @@ func LoadContractData(filename string) {
 			EggIncContractsNew = append(EggIncContractsNew, contract)
 		}
 
-		// Only add completely new contracts to this list
+		// Only add completely new contracts to this list, older contracts will be
+		// preserved in the history
 		if existingContract, exists := ei.EggIncContractsAll[c.ID]; !exists || contract.ValidFrom.After(existingContract.ValidFrom) {
+
+			if exists {
+				replaced := existingContract
+				replaced.History = nil
+				contract.History = append([]ei.EggIncContract{replaced}, existingContract.History...)
+			}
+
 			ei.EggIncContractsAll[c.ID] = contract
 		}
 
+	}
+
+	// Determine the amount of memory used by this structure
+	if config.IsDevBot() {
+		log.Printf("EggIncContractsAll memory usage: %d bytes (%.2f KB, %.2f MB)", estimateMapMemory(), float64(estimateMapMemory())/1024.0, float64(estimateMapMemory())/(1024.0*1024.0))
 	}
 
 	for _, predicted := range CreatePredictedContract() {
@@ -616,4 +631,44 @@ func updateContractWithEggIncData(s *discordgo.Session, contract *Contract) {
 		}
 		contract.PredictionInfo = pInfo
 	}
+}
+
+// estimateMapMemory returns the estimated memory footprint in bytes of ei.EggIncContractsAll
+func estimateMapMemory() int {
+	ei.EggIncContractsMutex.RLock()
+	defer ei.EggIncContractsMutex.RUnlock()
+	totalBytes := 48 + 8 // map header + pointer
+	for k, v := range ei.EggIncContractsAll {
+		totalBytes += 8 + 16 + len(k) // map bucket slot (8 byte hash + 16 byte string header + key len)
+		totalBytes += int(unsafe.Sizeof(v))
+		totalBytes += estimateContractMemory(v)
+	}
+	return totalBytes
+}
+func estimateContractMemory(c ei.EggIncContract) int {
+	bytes := 0
+	bytes += len(c.ID)
+	bytes += len(c.Proto)
+	bytes += len(c.Name)
+	bytes += len(c.Description)
+	bytes += len(c.EggName)
+	bytes += len(c.SeasonID)
+	bytes += cap(c.TargetAmount) * 8
+	bytes += cap(c.Grade) * int(unsafe.Sizeof(ei.ContractGrade{}))
+	for _, g := range c.Grade {
+		bytes += cap(g.TargetAmount) * 8
+	}
+	bytes += cap(c.TeamNames) * 16
+	for _, name := range c.TeamNames {
+		bytes += len(name)
+	}
+	bytes += cap(c.PredictionsList) * 16
+	for _, pred := range c.PredictionsList {
+		bytes += len(pred)
+	}
+	bytes += cap(c.History) * int(unsafe.Sizeof(ei.EggIncContract{}))
+	for _, hist := range c.History {
+		bytes += estimateContractMemory(hist)
+	}
+	return bytes
 }

--- a/src/boost/boost_import_test.go
+++ b/src/boost/boost_import_test.go
@@ -1,0 +1,134 @@
+package boost_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mkmccarty/TokenTimeBoostBot/src/boost"
+	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestLoadContractDataHistory(t *testing.T) {
+	gradeSpecs := []*ei.Contract_GradeSpec{
+		{
+			Grade: ei.Contract_GRADE_AAA.Enum(),
+			Goals: []*ei.Contract_Goal{
+				{
+					TargetAmount: proto.Float64(100000),
+					RewardType:   ei.RewardType_EGGS_OF_PROPHECY.Enum(),
+				},
+			},
+			LengthSeconds: proto.Float64(86400),
+		},
+	}
+
+	// Create mock contracts
+	c1Proto := &ei.Contract{
+		Identifier:     proto.String("test-history-contract"),
+		Name:           proto.String("Test History V1"),
+		ExpirationTime: proto.Float64(float64(time.Now().Add(10 * time.Hour).Unix())),
+		StartTime:      proto.Float64(float64(time.Now().Unix())),
+		GradeSpecs:     gradeSpecs,
+	}
+	c1Bin, err := proto.Marshal(c1Proto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// V2 is later (on the next day) to ensure ValidFrom is different after GetEggStandardTime
+	c2Proto := &ei.Contract{
+		Identifier:     proto.String("test-history-contract"),
+		Name:           proto.String("Test History V2"),
+		ExpirationTime: proto.Float64(float64(time.Now().Add(48 * time.Hour).Unix())),
+		StartTime:      proto.Float64(float64(time.Now().Add(24 * time.Hour).Unix())),
+		GradeSpecs:     gradeSpecs,
+	}
+	c2Bin, err := proto.Marshal(c2Proto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadedContracts := []ei.EggIncContract{
+		{
+			ID:    "test-history-contract",
+			Proto: base64.StdEncoding.EncodeToString(c1Bin),
+		},
+		{
+			ID:    "test-history-contract",
+			Proto: base64.StdEncoding.EncodeToString(c2Bin),
+		},
+	}
+
+	// Write to a temporary file
+	tmpFile, err := os.CreateTemp("", "contracts_*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
+
+	encoder := json.NewEncoder(tmpFile)
+	if err := encoder.Encode(loadedContracts); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpFile.Close()
+
+	// Clear global maps to avoid interference
+	ei.EggIncContractsAll = make(map[string]ei.EggIncContract)
+
+	// Load the contracts
+	boost.LoadContractData(tmpFile.Name())
+
+	// Verify the result
+	contract, exists := ei.EggIncContractsAll["test-history-contract"]
+	if !exists {
+		t.Fatalf("expected contract to exist in ei.EggIncContractsAll")
+	}
+
+	// The current version should be V2
+	if contract.Name != "Test History V2" {
+		t.Errorf("expected current name to be 'Test History V2', got '%s'", contract.Name)
+	}
+
+	// The history should have V1
+	if len(contract.History) != 1 {
+		t.Fatalf("expected history length to be 1, got %d", len(contract.History))
+	}
+
+	v1 := contract.History[0]
+	if v1.Name != "Test History V1" {
+		t.Errorf("expected history[0] name to be 'Test History V1', got '%s'", v1.Name)
+	}
+
+	if len(v1.History) != 0 {
+		t.Errorf("expected history[0].History to be empty, got %d elements", len(v1.History))
+	}
+
+	// Test GetEggIncContractByStartTime
+	// V1 start time is roughly now.
+	// V2 start time is 24 hours later.
+	v1StartTime := contract.History[0].ValidFrom
+	v2StartTime := contract.ValidFrom
+
+	// 1. Query at V2 start time -> should get V2
+	cRes, found := ei.GetEggIncContractByStartTime("test-history-contract", v2StartTime.Add(1*time.Hour))
+	if !found || cRes.Name != "Test History V2" {
+		t.Errorf("expected Test History V2 for time after V2 start, got name=%s (found=%t)", cRes.Name, found)
+	}
+
+	// 2. Query between V1 and V2 start times -> should get V1
+	cRes, found = ei.GetEggIncContractByStartTime("test-history-contract", v1StartTime.Add(5*time.Hour))
+	if !found || cRes.Name != "Test History V1" {
+		t.Errorf("expected Test History V1 for time between V1 and V2, got name=%s (found=%t)", cRes.Name, found)
+	}
+
+	// 3. Query before V1 start time -> should fallback to V1 (the oldest)
+	cRes, found = ei.GetEggIncContractByStartTime("test-history-contract", v1StartTime.Add(-5*time.Hour))
+	if !found || cRes.Name != "Test History V1" {
+		t.Errorf("expected Test History V1 fallback for time before V1, got name=%s (found=%t)", cRes.Name, found)
+	}
+}

--- a/src/ei/ei_data.go
+++ b/src/ei/ei_data.go
@@ -151,15 +151,16 @@ type EggIncContract struct {
 	Grade                     []ContractGrade
 	TeamNames                 []string // Names of the teams in the contract
 	// Contract Scoring Values
-	CxpBuffOnly     float64  // Minimum score with only CR/TVal
-	CxpRunDelta     float64  // Individual chicken run addition
-	Cxp             float64  // CXP value for the contract
-	CxpMax          float64  // Maximum CXP value based on EstimatedDurationMax
-	CxpMaxGG        float64  // Maximum CXP value based on EstimatedDurationMaxGG
-	CxpMaxSiab      float64  // Maximum CXP value based on SIAB usage
-	CxpMaxSiabGG    float64  // CXP value for the contract based on SIAB usage
-	SeasonalScoring int      // 0 = old (0.2.0), true = 1 (0.2.0+ seasonal change for AA+AAA)
-	PredictionsList []string // List of predictions for this contract
+	CxpBuffOnly     float64          // Minimum score with only CR/TVal
+	CxpRunDelta     float64          // Individual chicken run addition
+	Cxp             float64          // CXP value for the contract
+	CxpMax          float64          // Maximum CXP value based on EstimatedDurationMax
+	CxpMaxGG        float64          // Maximum CXP value based on EstimatedDurationMaxGG
+	CxpMaxSiab      float64          // Maximum CXP value based on SIAB usage
+	CxpMaxSiabGG    float64          // CXP value for the contract based on SIAB usage
+	SeasonalScoring int              // 0 = old (0.2.0), true = 1 (0.2.0+ seasonal change for AA+AAA)
+	PredictionsList []string         // List of predictions for this contract
+	History         []EggIncContract `json:"history,omitempty"` // History of replaced versions of this contract
 }
 
 // EggIncContracts holds a list of all contracts, newest is last
@@ -400,6 +401,34 @@ func GetEggIncContract(contractID string) (EggIncContract, bool) {
 	defer EggIncContractsMutex.RUnlock()
 	c, ok := EggIncContractsAll[contractID]
 	return c, ok
+}
+
+// GetEggIncContractByStartTime returns the version of the contract that was active at the given start time thread-safely.
+// It iterates through the history of the contract to find the one active at startTime.
+func GetEggIncContractByStartTime(contractID string, startTime time.Time) (EggIncContract, bool) {
+	EggIncContractsMutex.RLock()
+	defer EggIncContractsMutex.RUnlock()
+
+	c, ok := EggIncContractsAll[contractID]
+	if !ok {
+		return EggIncContract{}, false
+	}
+
+	if !startTime.Before(c.ValidFrom) {
+		return c, true
+	}
+
+	for _, h := range c.History {
+		if !startTime.Before(h.ValidFrom) {
+			return h, true
+		}
+	}
+
+	// Fallback to the oldest version if the start time is before any ValidFrom
+	if len(c.History) > 0 {
+		return c.History[len(c.History)-1], true
+	}
+	return c, true
 }
 
 // GetEggIncContractsSlice returns a copy of the EggIncContracts slice thread-safely


### PR DESCRIPTION
- Preserve previous contract when a newer version is loaded: if an existing contract is replaced, move the version into the new contract's History (with its own cleared) so update history is maintained without recursive duplication.
- Add GetEggIncContractByStartTime helper to retrieve contract version active at a given time (thread-safe).
- Add estimateMapMemory and estimateContractMemory functionsuses unsafe) to estimate memory footprint of ei.EggContractsAll for debugging; log memory when running in dev mode.
- Import unsafe and config packages, and log memory usage conditionally under dev mode.
- formatting/comment tweaks and alignment of struct tags and.

Reason: preserve historical contract data for correctness, enable time-
 lookups, provide memory visibility during development todiagnose resource usage.