### PR TITLE
✨ feat: add exact IGNDiscord lookup and use it scoringAdd GetDiscordUserIDFromEiIgnExact farmer to return the Discord ID for a given ei_ign collapsing accounts back totheir controller. The functiones pending saves and queries the DBdirectly, mirroring the non-collapsing behavior required by some callers.

### DIFF
--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -565,7 +565,7 @@ func GetContractArchivesForNames(s *discordgo.Session, names []string, cxpVersio
 				continue
 			}
 
-			discordID, e := farmerstate.GetDiscordUserIDFromEiIgn(name)
+			discordID, e := farmerstate.GetDiscordUserIDFromEiIgnExact(name)
 			if e != nil && config.IsDevBot() {
 				log.Printf("GetContractArchivesForNames: IGN->discordID lookup failed name=%q: %v", name, e)
 			}

--- a/src/farmerstate/farmerstate.go
+++ b/src/farmerstate/farmerstate.go
@@ -608,6 +608,17 @@ func GetEiIgnsByGuild(guildID string) []string {
 	return eiIgns
 }
 
+// GetDiscordUserIDFromEiIgnExact retrieves the Discord user ID based on the provided ei_ign
+// without collapsing alternate accounts back to their controller.
+func GetDiscordUserIDFromEiIgnExact(eiIgn string) (string, error) {
+	FlushPendingSaves()
+	id, err := queries.GetUserIdFromEiIgn(ctx, sql.NullString{String: eiIgn, Valid: true})
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
 // GetDiscordUserIDFromEiIgn retrieves the Discord user ID based on the provided ei_ign.
 // It also checks if the account is an alternate and returns the parent's Discord ID if so.
 func GetDiscordUserIDFromEiIgn(eiIgn string) (string, error) {

--- a/src/farmerstate/farmerstate_test.go
+++ b/src/farmerstate/farmerstate_test.go
@@ -116,3 +116,25 @@ func TestGuildMembership(t *testing.T) {
 		t.Errorf("after remove, GetGuildMembers() = %v, want [gm_user2]", members)
 	}
 }
+
+func TestGetDiscordUserIDFromEiIgnExactDoesNotCollapseAlt(t *testing.T) {
+	SetMiscSettingString("main-user", "ei_ign", "MainFarmer")
+	SetMiscSettingString("alt-user", "ei_ign", "AltFarmer")
+	SetMiscSettingString("alt-user", "AltController", "main-user")
+
+	gotExact, err := GetDiscordUserIDFromEiIgnExact("AltFarmer")
+	if err != nil {
+		t.Fatalf("GetDiscordUserIDFromEiIgnExact() returned error: %v", err)
+	}
+	if gotExact != "alt-user" {
+		t.Fatalf("GetDiscordUserIDFromEiIgnExact() = %q, want %q", gotExact, "alt-user")
+	}
+
+	gotCollapsed, err := GetDiscordUserIDFromEiIgn("AltFarmer")
+	if err != nil {
+		t.Fatalf("GetDiscordUserIDFromEiIgn() returned error: %v", err)
+	}
+	if gotCollapsed != "main-user" {
+		t.Fatalf("GetDiscordUserIDFromEiIgn() = %q, want %q", gotCollapsed, "main-user")
+	}
+}


### PR DESCRIPTION
Add a unit test TestGetDiscordUserIDFromEiIgnExactDoesNotCollapseAlt toverify that GetDiscordUserIDFromEiIgnExact returns alt Discordwhile the existing GetDiscordUserIDFromEiIgn returns the maincontroller's ID when an account is configured as an alternate.

Update boost/estimate_scores to call the new Exact lookup whenresolving names for estimation, avoiding inadvertent collapsingof alternate accounts during score calculations.