### PR TITLE
✨ fix: unify contract identifier retrieval across codebaseNormalize how LocalContract and archived contract identifiers areobtained byerring the GetContractIdentifier() helper and onlyfalling back nested Contract or Evaluation getters when that helperreturns an empty string.

### DIFF
--- a/src/boost/artifacts.go
+++ b/src/boost/artifacts.go
@@ -131,11 +131,16 @@ func populateColleggtiblesFromBackup(userID string, backup *ei.Backup) ([]string
 		if c == nil {
 			continue
 		}
+		contractID := c.GetContractIdentifier()
+		if contractID == "" && c.GetContract() != nil {
+			contractID = c.GetContract().GetIdentifier()
+		} else if contractID == "" && c.GetEvaluation() != nil {
+			contractID = c.GetEvaluation().GetContractIdentifier()
+		}
 		eggID := ""
 		if c.GetContract() != nil {
 			eggID = c.GetContract().GetCustomEggId()
-		} else if c.GetEvaluation() != nil {
-			contractID := c.GetEvaluation().GetContractIdentifier()
+		} else if contractID != "" {
 			if contractInfo, ok := ei.GetEggIncContract(contractID); ok {
 				if contractInfo.Egg == int32(ei.Egg_CUSTOM_EGG) {
 					eggID = contractInfo.EggName

--- a/src/boost/contract_report.go
+++ b/src/boost/contract_report.go
@@ -429,10 +429,10 @@ func ContractReport(
 	cxpVersion := ""
 	var callerEval *ei.ContractEvaluation
 	for _, lc := range callerArchive {
-		lcContractID := ""
-		if lc.GetContract() != nil {
+		lcContractID := lc.GetContractIdentifier()
+		if lcContractID == "" && lc.GetContract() != nil {
 			lcContractID = lc.GetContract().GetIdentifier()
-		} else if lc.GetEvaluation() != nil {
+		} else if lcContractID == "" && lc.GetEvaluation() != nil {
 			lcContractID = lc.GetEvaluation().GetContractIdentifier()
 		}
 		// Check if we have an evaluation with the given contract ID
@@ -877,10 +877,10 @@ func deriveThresholds(p *contractReportParameters) thresholds {
 // pick the evaluation for a specific contractID from an archive
 func evalForContract(archive []*ei.LocalContract, contractID, coopID string) *ei.ContractEvaluation {
 	for _, lc := range archive {
-		lcContractID := ""
-		if lc.GetContract() != nil {
+		lcContractID := lc.GetContractIdentifier()
+		if lcContractID == "" && lc.GetContract() != nil {
 			lcContractID = lc.GetContract().GetIdentifier()
-		} else if lc.GetEvaluation() != nil {
+		} else if lcContractID == "" && lc.GetEvaluation() != nil {
 			lcContractID = lc.GetEvaluation().GetContractIdentifier()
 		}
 		if lcContractID == contractID && lc.GetEvaluation() != nil && lc.GetEvaluation().GetCoopIdentifier() == coopID {

--- a/src/boost/estimate_scores.go
+++ b/src/boost/estimate_scores.go
@@ -651,10 +651,10 @@ func prevCXPFromArchive(arch []*ei.LocalContract, contractID, currentCoopID stri
 		if ev == nil {
 			continue
 		}
-		lcContractID := ""
-		if lc.GetContract() != nil {
+		lcContractID := lc.GetContractIdentifier()
+		if lcContractID == "" && lc.GetContract() != nil {
 			lcContractID = lc.GetContract().GetIdentifier()
-		} else {
+		} else if lcContractID == "" {
 			lcContractID = ev.GetContractIdentifier()
 		}
 		if lcContractID != contractID {

--- a/src/boost/rerun-active.go
+++ b/src/boost/rerun-active.go
@@ -47,11 +47,11 @@ func printActiveContractDetails(userID string, archive []*ei.LocalContract, cont
 			1.15: "T4C", 1.17: "T4R", 1.19: "T4E", 1.20: "T4L",
 		}
 
-		contractID := ""
+		contractID := a.GetContractIdentifier()
 		evaluation := a.GetEvaluation()
-		if a.GetContract() != nil {
+		if contractID == "" && a.GetContract() != nil {
 			contractID = a.GetContract().GetIdentifier()
-		} else if evaluation != nil {
+		} else if contractID == "" && evaluation != nil {
 			contractID = evaluation.GetContractIdentifier()
 		}
 		if contractID == "first-contract" || contractID == "" {

--- a/src/boost/rerun-chart.go
+++ b/src/boost/rerun-chart.go
@@ -89,11 +89,11 @@ func printContractChart(userID string, archive []*ei.LocalContract, percent int,
 	log.Printf("Downloaded %d archived contracts from Egg Inc API for %s\n", len(archive), eiUserName)
 
 	for _, a := range archive {
-		contractID := ""
+		contractID := a.GetContractIdentifier()
 		evaluation := a.GetEvaluation()
-		if a.GetContract() != nil {
+		if contractID == "" && a.GetContract() != nil {
 			contractID = a.GetContract().GetIdentifier()
-		} else if evaluation != nil {
+		} else if contractID == "" && evaluation != nil {
 			contractID = evaluation.GetContractIdentifier()
 		}
 		if contractID == "first-contract" || contractID == "" {

--- a/src/dashboard/dashboard.go
+++ b/src/dashboard/dashboard.go
@@ -353,10 +353,10 @@ func drawDashboard(s *discordgo.Session, userID string, showExternal bool) []dis
 						coopID := ""
 						if backup.GetContracts() != nil {
 							for _, lc := range backup.GetContracts().GetContracts() {
-								lcContractID := ""
-								if lc.GetContract() != nil {
+								lcContractID := lc.GetContractIdentifier()
+								if lcContractID == "" && lc.GetContract() != nil {
 									lcContractID = lc.GetContract().GetIdentifier()
-								} else if lc.GetEvaluation() != nil {
+								} else if lcContractID == "" && lc.GetEvaluation() != nil {
 									lcContractID = lc.GetEvaluation().GetContractIdentifier()
 								}
 								if lcContractID == contractID {

--- a/src/ei/ei_colleggtibles.go
+++ b/src/ei/ei_colleggtibles.go
@@ -83,11 +83,17 @@ func GetColleggtibleBuffs(contracts *MyContracts) DimensionBuffs {
 
 	// Look in active and archived contracts for custom eggs
 	for _, c := range append(contracts.GetArchive(), contracts.GetContracts()...) {
+		contractID := c.GetContractIdentifier()
+		if contractID == "" && c.GetContract() != nil {
+			contractID = c.GetContract().GetIdentifier()
+		} else if contractID == "" && c.GetEvaluation() != nil {
+			contractID = c.GetEvaluation().GetContractIdentifier()
+		}
+
 		egg := ""
 		if c.GetContract() != nil {
 			egg = c.GetContract().GetCustomEggId()
-		} else if c.GetEvaluation() != nil {
-			contractID := c.GetEvaluation().GetContractIdentifier()
+		} else if contractID != "" {
 			if contractInfo, ok := GetEggIncContract(contractID); ok {
 				if contractInfo.Egg == int32(Egg_CUSTOM_EGG) {
 					egg = contractInfo.EggName


### PR DESCRIPTION
Key changes:
- Replace ad-hoc empty-string initialization with a call toContractIdentifier() in boost, ei and dashboard packages.
- Add conditional fallbacks to Contract.GetIdentifier() or Evaluation.GetContractIdentifier() only whenContractIdentifier()
 returns "".
- Adjust logic that previously re-read evaluation contract IDs in else branches to use the computed contractID when.
- Fix where egg/customegg lookup and evaluation selection relied on different ways of computing contract IDs.

Why:
- duplicated and inconsistent identifier retrieval.
- Ensure consistent precedence: explicit stored contract identifier (GetContract) is used first, then Contract, then Evaluation.
- Prevent mismatches and subtle when multiple identifier exist or the helper already encapsulates correct.