### PR TITLE
✨ feat: log followup message ID only onPrint the message ID returned from FollowupMessageEdit inside thesuccess branch instead of unconditionally. This avoids referencing apossibly nil msg when an occurs and prevents logsAlso retain error logging when FollowupMessageEdit fails.

### DIFF
--- a/src/boost/stones_pages.go
+++ b/src/boost/stones_pages.go
@@ -270,8 +270,9 @@ func sendStonesPage(s *discordgo.Session, i *discordgo.InteractionCreate, newMes
 		msg, err := s.FollowupMessageEdit(i.Interaction, i.Message.ID, &d2)
 		if err != nil {
 			log.Println(err)
+		} else {
+			log.Print(msg.ID)
 		}
-		log.Print(msg.ID)
 	}
 	stonesCacheMutex.Lock()
 	stonesCacheMap[cache.xid] = cache


### PR DESCRIPTION
- Move.Print.ID) into the else branch to run only success.
- Preserve existing error logging for failuresThis fixes a potential nil dereference and improves log accuracy.