### PR TITLE
:spark: feat(leaderboard): handle widths truncating namesUpdate name trunc and display width calculations to account foremoji and wide runes so table align correctly inospcontexts.

### DIFF
--- a/src/leaderboard/leaderboard_post.go
+++ b/src/leaderboard/leaderboard_post.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/mattn/go-runewidth"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/bottools"
 	"github.com/mkmccarty/TokenTimeBoostBot/src/ei"
 )
@@ -540,7 +541,7 @@ func buildMessageBlocks(def LBDef, rows []LBEntry, snapDate string, prevMap map[
 func renderTable(def LBDef, rows []LBEntry, prevMap map[string]float64, rankOffset int) (string, []string, string) {
 	_ = prevMap
 
-	const maxNameChars = 15
+	const maxNameChars = 14
 	maxNameWidth := len("Name")
 
 	shortDisplayName := def.DisplayName
@@ -682,7 +683,7 @@ func renderTable(def LBDef, rows []LBEntry, prevMap map[string]float64, rankOffs
 		}
 
 		nameStr := truncateString(r.GameName, maxNameChars)
-		if w := len(nameStr); w > maxNameWidth {
+		if w := runewidth.StringWidth(nameStr); w > maxNameWidth {
 			maxNameWidth = w
 		}
 
@@ -983,15 +984,15 @@ func absFloat(v float64) float64 {
 	return v
 }
 
-// truncateString ensures a string is at most max characters, adding … if needed
+// truncateString ensures a string is at most max monospaced characters wide, adding … if needed
 func truncateString(s string, max int) string {
-	if len(s) <= max {
+	if runewidth.StringWidth(s) <= max {
 		return s
 	}
-	if max <= 3 {
-		return s[:max]
+	if max <= 1 {
+		return runewidth.Truncate(s, max, "")
 	}
-	return s[:max-3]
+	return runewidth.Truncate(s, max, "…")
 }
 
 // FormatLBValue formats a numeric leaderboard value according to the LBDef.ValueFmt.

--- a/src/leaderboard/leaderboard_post_test.go
+++ b/src/leaderboard/leaderboard_post_test.go
@@ -218,3 +218,27 @@ func TestRenderTable_SoulMirrorsDynamicSpacing(t *testing.T) {
 		t.Fatalf("did not expect fixed 5-character Soul Mirrors row spacing, got %q / %q", rowLines[0], rowLines[1])
 	}
 }
+
+func TestTruncateString_EmojisAndWidth(t *testing.T) {
+	tests := []struct {
+		input    string
+		max      int
+		expected string
+	}{
+		{"ShortName", 14, "ShortName"},
+		{"Exactly14Chars", 14, "Exactly14Chars"},
+		{"WayTooLongNameHere", 14, "WayTooLongNam…"},
+		{"Emoji🚀Name", 14, "Emoji🚀Name"},
+		{"🚀🚀🚀🚀🚀🚀🚀", 14, "🚀🚀🚀🚀🚀🚀🚀"}, // 7 * 2 = 14 width
+		{"🚀🚀🚀🚀🚀🚀🚀🚀", 14, "🚀🚀🚀🚀🚀🚀…"}, // 8 * 2 = 16 width, so truncate. "…" is width 1, 6 * 2 = 12, total 13 width <= 14.
+		{"🚀🚀🚀🚀🚀🚀🚀A", 14, "🚀🚀🚀🚀🚀🚀…"}, // 7*2 + 1 = 15 width. 6 * 2 = 12 + "…" (1) = 13 <= 14.
+		{"Emoji🚀🚀🚀🚀🚀🚀", 14, "Emoji🚀🚀🚀🚀…"}, // 5 + 6*2 = 17 width. "Emoji" (5) + 4*2 (8) + "…" (1) = 14 <= 14.
+	}
+
+	for _, tt := range tests {
+		result := truncateString(tt.input, tt.max)
+		if result != tt.expected {
+			t.Errorf("truncateString(%q, %d) = %q; want %q", tt.input, tt.max, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
- add-runewidth import and use runewidthWidth when measuring width of truncated names- change max name width from15 to14 to match target column sizing- naive byte/char truncation with runewidth.Tr to safely trim multibyte and wide characters and append an ellipsis- adjust small-max handling to avoid slicing in the middle of runes- add tests covering emoji and mixed-width truncation scenariosThis prevents misaligned leaderboard rows and incorrect truncation foremoji-heavy names.