### PR TITLE
✨ feat(leaderboard): add Header "Launched" to leaderboardsAdd a HeaderName field with the value "unched to standard andvirtue leaderboard definitions in leaderboard.go. This fills thepreviously empty header metadata so UI components and exporters have aconsistent label for launch counts.

### DIFF
--- a/src/leaderboard/leaderboard.go
+++ b/src/leaderboard/leaderboard.go
@@ -236,6 +236,7 @@ func init() {
 		AllLeaderboards = append(AllLeaderboards, LBDef{
 			Key:              stdKey,
 			DisplayName:      name,
+			HeaderName:       "Launched",
 			Description:      fmt.Sprintf("Total launches for the %s.", name),
 			ValueFmt:         "int",
 			HigherIsBetter:   true,
@@ -247,6 +248,7 @@ func init() {
 		AllLeaderboards = append(AllLeaderboards, LBDef{
 			Key:              virtueKey,
 			DisplayName:      "Virtue " + name,
+			HeaderName:       "Launched",
 			Description:      fmt.Sprintf("Total virtue launches for the %s.", name),
 			ValueFmt:         "int",
 			HigherIsBetter:   true,


### PR DESCRIPTION
This change improves display consistency and makes the naming for downstream consumers.