### PR TITLE
✨ fix CTE column labels and descriptionsUpdate CTE labels and widths to consistently use "CTE"

### DIFF
--- a/src/leaderboard/leaderboard.go
+++ b/src/leaderboard/leaderboard.go
@@ -109,7 +109,7 @@ var AllLeaderboards = []LBDef{
 	{Key: LBEarningsBonus, DisplayName: "Earnings Bonus", Description: "Nekkid and Dressed earnings bonus.", ValueFmt: "eb", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
 	{Key: LBVirtueShifts, DisplayName: "Virtue Shifts", HeaderName: "Shifts", Description: "Total virtue shifts completed.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
 	{Key: LBTETotal, DisplayName: "Total Truth Eggs", HeaderName: "TE", Description: "Sum of truth eggs across all virtues.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
-	{Key: LBCTETotal, DisplayName: "Total CTE", HeaderName: "CTE", Description: "Current clothed Truth Egg equivalent.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
+	{Key: LBCTETotal, DisplayName: "Total CTE", HeaderName: "CTE", Description: "Clothed Truth Egg equivalent for pending and current TE.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
 	{Key: LBTEPerShift, DisplayName: "TE per Shift", HeaderName: "TE/Shift", Description: "Average Truth Eggs earned per Virtue Shift.", ValueFmt: "float", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
 	{Key: LBDrones, DisplayName: "Drones", Description: "Total drones taken down.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},
 	{Key: LBEliteDrones, DisplayName: "Elite Drones", Description: "Total elite drones taken down.", ValueFmt: "int", HigherIsBetter: true, Source: SourceFirstContact, RetainRecentOnly: true},

--- a/src/leaderboard/leaderboard_post.go
+++ b/src/leaderboard/leaderboard_post.go
@@ -570,13 +570,13 @@ func renderTable(def LBDef, rows []LBEntry, prevMap map[string]float64, rankOffs
 	hasCTEComparisonColumn := def.Key == LBCTETotal
 	hasTEColumn := def.Key == LBEggsCuriosity || def.Key == LBEggsIntegrity || def.Key == LBEggsHumility || def.Key == LBEggsResilience || def.Key == LBEggsKindness || def.Key == LBVirtueEggsSum
 	teWidth := len("TE")
-	actualCTEWidth := len("Actual CTE")
+	actualCTEWidth := len("CTE")
 	soulMirrorCommonWidth := len("C")
 	soulMirrorEpicWidth := len("E")
 	soulMirrorLegendaryWidth := len("L")
 	const soulMirrorMaxDigits = 5
 	if hasCTEComparisonColumn {
-		maxValOnlyWidth = len("Future CTE")
+		maxValOnlyWidth = len("Pending")
 	}
 	if isEB {
 		maxValOnlyWidth = len("Nekkid")
@@ -828,7 +828,7 @@ func renderTable(def LBDef, rows []LBEntry, prevMap map[string]float64, rankOffs
 		headerLine := strings.Join([]string{
 			padField(rankHeader, rankWidth, bottools.StringAlignLeft),
 			padField("Name", maxNameWidth, bottools.StringAlignLeft),
-			padField("Pending CTE", maxValOnlyWidth, bottools.StringAlignRight),
+			padField("Pending", maxValOnlyWidth, bottools.StringAlignRight),
 			padField("CTE", actualCTEWidth, bottools.StringAlignRight),
 		}, "|")
 		colHeader = fmt.Sprintf("```\n%s\n%s\n", headerLine, strings.Repeat("-", len(headerLine)))

--- a/src/leaderboard/leaderboard_post_test.go
+++ b/src/leaderboard/leaderboard_post_test.go
@@ -119,7 +119,7 @@ func TestRenderTable_AllLeaderboards(t *testing.T) {
 			}
 
 			if withCTEComparisonColumns[def.Key] {
-				if !strings.Contains(colHeader, "Pending CTE") || !strings.Contains(colHeader, "CTE") {
+				if !strings.Contains(colHeader, "Pending") || !strings.Contains(colHeader, "CTE") {
 					t.Fatalf("expected CTE comparison columns for %s, got %q", def.Key, colHeader)
 				}
 				if !strings.Contains(line, "12,345") || !strings.Contains(line, "12,000") {


### PR DESCRIPTION
and "Pending" instead of "Pending C" and " CTE". Adjust theactual CTE header width to match shorter "CTE" label.

 Use "Pending" for the pending comparison column header and width.
- UseCTE" (not "Actual CTE for the CTE column calculation.
- Tighten description for LBCTETotal to clarify it covers both pending and current TE.

These changes fix header rendering and in the leaderboardoutput and make LBCTETotal description clearer for consumers.