### PR TITLE
✨ feat bump default build111344Update the default build number111342 to111344 to keepthe bundled API client in with the latest server build.

### DIFF
--- a/src/ei/ei_default_values.go
+++ b/src/ei/ei_default_values.go
@@ -15,5 +15,5 @@ const (
 	DefaultVersion = "1.35.7"
 
 	// DefaultBuild is the build number used for API requests
-	DefaultBuild = "111342"
+	DefaultBuild = "111344"
 )


### PR DESCRIPTION
prevents version mismatch issues when making API requeststhat depend on the current build.