### PR TITLE
✨feat: append reaction buttons to boost message componentsAddContractReactionsComponents output to all places where boostlist components are built reaction buttons are consistently includedin created and updated messages.

### DIFF
--- a/src/boost/boost.go
+++ b/src/boost/boost.go
@@ -1311,6 +1311,10 @@ func RemoveFarmerByMention(s *discordgo.Session, guildID string, channelID strin
 		}
 		msgedit := discordgo.NewMessageEdit(loc.ChannelID, loc.ListMsgID)
 		components := DrawBoostList(s, contract)
+		buttonComponents := getContractReactionsComponents(contract)
+		if len(buttonComponents) > 0 {
+			components = append(components, buttonComponents...)
+		}
 		msgedit.Components = &components
 		msgedit.Flags = discordgo.MessageFlagsIsComponentsV2
 		msg, err := s.ChannelMessageEditComplex(msgedit)

--- a/src/boost/boost_slashcmd.go
+++ b/src/boost/boost_slashcmd.go
@@ -737,6 +737,10 @@ func HandleRestartContract(s *discordgo.Session, i *discordgo.InteractionCreate)
 					newContract.BoostOrder = boostOrder
 
 					createMsg := DrawBoostList(s, newContract)
+					buttonComponents := getContractReactionsComponents(newContract)
+					if len(buttonComponents) > 0 {
+						createMsg = append(createMsg, buttonComponents...)
+					}
 					var listData discordgo.MessageSend
 					listData.Components = createMsg
 					listData.Flags = discordgo.MessageFlagsIsComponentsV2

--- a/src/boost/boost_speedrun.go
+++ b/src/boost/boost_speedrun.go
@@ -271,6 +271,10 @@ func setSpeedrunOptions(s *discordgo.Session, channelID string, sinkBoosting str
 	for _, loc := range contract.Location {
 		msgedit := discordgo.NewMessageEdit(loc.ChannelID, loc.ListMsgID)
 		components := DrawBoostList(s, contract)
+		buttonComponents := getContractReactionsComponents(contract)
+		if len(buttonComponents) > 0 {
+			components = append(components, buttonComponents...)
+		}
 		msgedit.Components = &components
 		msgedit.Flags = discordgo.MessageFlagsIsComponentsV2
 		//msgedit.SetComponents(contentStr)

--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -385,6 +385,10 @@ func HandleContractCommand(s *discordgo.Session, i *discordgo.InteractionCreate)
 	}
 
 	var createMsg = DrawBoostList(s, contract)
+	buttonComponents := getContractReactionsComponents(contract)
+	if len(buttonComponents) > 0 {
+		createMsg = append(createMsg, buttonComponents...)
+	}
 	var data discordgo.MessageSend
 	data.Components = createMsg
 	data.Flags = discordgo.MessageFlagsIsComponentsV2

--- a/src/boost/message_redraw.go
+++ b/src/boost/message_redraw.go
@@ -206,6 +206,10 @@ func sendNextNotification(s *discordgo.Session, contract *Contract, pingUsers bo
 			// Full contract for speedrun
 			listComp := DrawBoostList(s, contract)
 			components = append(components, listComp...)
+			buttonComponents := getContractReactionsComponents(contract)
+			if len(buttonComponents) > 0 {
+				components = append(components, buttonComponents...)
+			}
 			msgedit.Components = &components
 			msgedit.Flags = discordgo.MessageFlagsIsComponentsV2
 			_, err := s.ChannelMessageEditComplex(msgedit)


### PR DESCRIPTION
- Append returned button components creating a new boost message (boost_slashcmd, contract).
- Append button components when editing existing list messages for speedrun and regular updates (boost_speedrun boost, message_redraw).
- Guard with length checks to avoid appending empty slices.

This ensures interactive reaction buttons appear alongside listsboth on creation and on subsequent redraws/its