### PR TITLE
✨ feat: bump default app to135.8Update DefaultVersion from1.35.7 to1.35.8 in ei_default_values.go.

### DIFF
--- a/src/ei/ei_default_values.go
+++ b/src/ei/ei_default_values.go
@@ -12,7 +12,7 @@ const (
 	DefaultPlatformString = "IOS"
 
 	// DefaultVersion is the app version used for API requests
-	DefaultVersion = "1.35.7"
+	DefaultVersion = "1.35.8"
 
 	// DefaultBuild is the build number used for API requests
 	DefaultBuild = "111344"


### PR DESCRIPTION
This ensures API requests and any that relies on the embeddeddefault version reflect the new release. Keeps default build/versionmetadata consistent with the latest app update.