### PR TITLE
feat guard against nil booster when building alts listFix potential panic accessing contract.Bosters[sid].Alts bychecking map lookup and nil pointer before appending Alt entries.

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -784,7 +784,10 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 
 	case "boostsink":
 		sid := getInteractionUserID(i)
-		alts := append([]string{sid}, contract.Boosters[sid].Alts...)
+		alts := []string{sid}
+		if booster, ok := contract.Boosters[sid]; ok && booster != nil {
+			alts = append(alts, booster.Alts...)
+		}
 		altIdx := slices.Index(alts, contract.Banker.BoostingSinkUserID)
 		if altIdx != -1 {
 			if altIdx != len(alts)-1 {
@@ -804,7 +807,10 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		}
 	case "postsink":
 		sid := getInteractionUserID(i)
-		alts := append([]string{sid}, contract.Boosters[sid].Alts...)
+		alts := []string{sid}
+		if booster, ok := contract.Boosters[sid]; ok && booster != nil {
+			alts = append(alts, booster.Alts...)
+		}
 		altIdx := slices.Index(alts, contract.Banker.PostSinkUserID)
 		if altIdx != -1 {
 			if altIdx != len(alts)-1 {


### PR DESCRIPTION
Replace append a safe sequence:
- initialize alts with sid- if booster exists and is non-nil, append boostertsThis change prevents runtime crashes for missing or nil booster in both boostsink and postsink handling.