### PR TITLE
✨ feat(contract): validate user is a booster before sink changesPrevent nil or missing booster entries from silently allowingmodifications and give immediate feedback to the interacting user.

### DIFF
--- a/src/boost/contract.go
+++ b/src/boost/contract.go
@@ -784,10 +784,17 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 
 	case "boostsink":
 		sid := getInteractionUserID(i)
-		alts := []string{sid}
-		if booster, ok := contract.Boosters[sid]; ok && booster != nil {
-			alts = append(alts, booster.Alts...)
+		booster, ok := contract.Boosters[sid]
+		if !ok || booster == nil {
+			_, _ = s.FollowupMessageCreate(i.Interaction, true,
+				&discordgo.WebhookParams{
+					Content: "You're not in this contract, so you can't modify sink selections.",
+					Flags:   discordgo.MessageFlagsEphemeral,
+				})
+			return
 		}
+		alts := []string{sid}
+		alts = append(alts, booster.Alts...)
 		altIdx := slices.Index(alts, contract.Banker.BoostingSinkUserID)
 		if altIdx != -1 {
 			if altIdx != len(alts)-1 {
@@ -807,10 +814,17 @@ func HandleContractSettingsReactions(s *discordgo.Session, i *discordgo.Interact
 		}
 	case "postsink":
 		sid := getInteractionUserID(i)
-		alts := []string{sid}
-		if booster, ok := contract.Boosters[sid]; ok && booster != nil {
-			alts = append(alts, booster.Alts...)
+		booster, ok := contract.Boosters[sid]
+		if !ok || booster == nil {
+			_, _ = s.FollowupMessageCreate(i.Interaction, true,
+				&discordgo.WebhookParams{
+					Content: "You're not in this contract, so you can't modify sink selections.",
+					Flags:   discordgo.MessageFlagsEphemeral,
+				})
+			return
 		}
+		alts := []string{sid}
+		alts = append(alts, booster.Alts...)
 		altIdx := slices.Index(alts, contract.Banker.PostSinkUserID)
 		if altIdx != -1 {
 			if altIdx != len(alts)-1 {


### PR DESCRIPTION
- Add explicit check for contractoosters[s] presence and non-nil for both "boostsink" and "postsink" interaction handlers.
- If the user is not part of the contract, an ephemeral followup message explaining they cannot modify sink selections and return early to avoid accessing nil data.
- Re alt slice construction to occur after the presence check avoid dere and make intent.

This avoids runtime errors improves UX by informing usersthey attempt change sinks but not members of the contract